### PR TITLE
Fix errors in Temporal types serialization

### DIFF
--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -51,7 +51,7 @@ export default class HttpConnectionProvider extends ConnectionProvider {
     async acquireConnection(param?: { accessMode?: string | undefined; database?: string | undefined; bookmarks: internal.bookmarks.Bookmarks; impersonatedUser?: string | undefined; onDatabaseNameResolved?: ((databaseName?: string | undefined) => void) | undefined; auth?: types.AuthToken | undefined } | undefined): Promise<Connection & Releasable> {
         const auth = param?.auth ?? await this._authTokenManager.getToken()
         
-        return new HttpConnection({ release: async () => console.log('release'), auth, address: this._address, database: (param?.database ?? 'neo4j'), scheme: this._scheme, config: this._config }) 
+        return new HttpConnection({ release: async () => {}, auth, address: this._address, database: (param?.database ?? 'neo4j'), scheme: this._scheme, config: this._config }) 
     }
 
 

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -84,7 +84,6 @@ export default class HttpConnection extends Connection {
             })
             .catch((error) => observer.onError(error))
             .then(async ([contentType, rawQueryResponse]: [string, RawQueryResponse]) => {
-                console.log(JSON.stringify(rawQueryResponse, undefined, 4))
                 if (rawQueryResponse == null) {
                     // is already dead
                     return

--- a/src/http-connection/stream-observers.ts
+++ b/src/http-connection/stream-observers.ts
@@ -161,7 +161,6 @@ export class ResultStreamObserver implements internal.observer.ResultStreamObser
         }
 
         if (this._afterComplete) {
-            console.log('afterComplete', completionMetadata)
             this._afterComplete(completionMetadata)
         }
 

--- a/test/integration/config/index.ts
+++ b/test/integration/config/index.ts
@@ -33,6 +33,7 @@ const testcontainersDisabled = env.TEST_CONTAINERS_DISABLED !== undefined
   ? env.TEST_CONTAINERS_DISABLED.toUpperCase() === 'TRUE'
   : false
 
+const database = 'neo4j'
 const cluster = env.TEST_NEO4J_IS_CLUSTER === '1'
 
 const neo4jContainer = new Neo4jContainer(username, password, version, edition, testcontainersDisabled, printContainerLogs)
@@ -43,6 +44,7 @@ export default {
   hostname,
   scheme,
   cluster,
+  database,
   get testNonClusterSafe () {
     return cluster ? test.skip.bind(test) : test
   },

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -15,24 +15,71 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Config from './config'
-import neo4j, { Wrapper } from '../../src'
+import config from './config'
+import neo4j, { Date, DateTime, Duration, LocalDateTime, LocalTime, Point, Time, Wrapper, int } from '../../src'
+
+const NESTED_OBJECT = { 
+  a: { 
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4
+  }, 
+  b: {
+    a: true,
+    b: false
+  },
+  c: {
+    a: 1.1,
+    b: 2.2,
+    c: 3.3
+  },
+  d: {
+    a: 'a',
+    b: 'b',
+    c: 'c',
+    temp: '˚C'
+  },
+  e: {
+    a: null
+  },
+  f: {
+    a: int(1),
+    b: true,
+    c: 3.3,
+    d: 'Hello, world!',
+    e: null
+  }
+}
+
+const LIST_OF_OBJECTS = [{
+  a: 1,
+  b: 2
+}, {
+  c: 3,
+  d: 4
+}]
+
+const OBJECT_OF_LISTS = {
+  a: [1],
+  b: [1, 2]
+}
 
 describe('minimum requirement', () => {
   let wrapper: Wrapper
 
   beforeAll(async () => {
-    await Config.startNeo4j()
+    await config.startNeo4j()
   }, 120_000) // long timeout since it may need to download docker image
 
   afterAll(async () => {
-    await Config.stopNeo4j()
+    await config.stopNeo4j()
   }, 20000)
 
   beforeEach(() => {
     wrapper = neo4j.wrapper(
-      `http://${Config.hostname}:${Config.httpPort}`,
-      neo4j.auth.basic(Config.username, Config.password)
+      `http://${config.hostname}:${config.httpPort}`,
+      neo4j.auth.basic(config.username, config.password)
     )
   })
 
@@ -41,6 +88,91 @@ describe('minimum requirement', () => {
   })
 
   it('should verifyConnectivity', async () => {
-    await expect(wrapper.verifyConnectivity({ database: 'neo4j' })).resolves.toBeDefined()
+    await expect(wrapper.verifyConnectivity({ database: config.database })).resolves.toBeDefined()
   })
+
+  it.each([
+    // bool
+    ['bool', v(true)],
+    ['bool', v(false)],
+    // null
+    ['null', v(null)],
+    // integer
+    ['Integer', v(int(1))],
+    ['Integer', v(int(-7))],
+    ['Integer', v(int(-129))],
+    ['Integer', v(int(129))],
+    ['Integer', v(int(2147483647))],
+    ['Integer', v(int(-2147483648))],
+    // bigint
+    ['bigint', v(1n, int)],
+    ['bigint', v(-7n, int)],
+    ['bigint', v(-129n, int)],
+    ['bigint', v(129n, int)],
+    ['bigint', v(2147483647n, int)],
+    ['bigint', v(-2147483648n, int)],
+    // number
+    ['number', v(0)],
+    ['number', v(0.0)],
+    ['number', v(Number.POSITIVE_INFINITY)],
+    ['number', v(Number.NEGATIVE_INFINITY)],
+    ['number', v(Number.NaN)],
+    ['number', v(1)],
+    ['number', v(-1)],
+    ['number', v(2**1023)], // max exponent
+    ['number', v(2**-1022)], // min exponent
+    ['number', v(9007199254740991)], // max mantissa
+    ['number', v(-9007199254740991)], // min mantissa
+    ['number', v(-(2 + 1 + 2e-51))],
+    // string
+    ['string', v('')],
+    ['string', v('1')],
+    ['string', v('-17∂ßå®')],
+    ['string', v('String')],
+    // list
+    ['list', v(["Hello", int(1134), "World"])],
+    ['list', v(new Set(["Hello", int(1134), "World"]), s => [...s])],
+    // object
+    ['object', v({ a: 'Hello', b: 1234, c: 'World' })],
+    
+    // The following doesn't work, it returns as [['a', 'Hello'], ['b', 1234], ['c', 'World']]
+    // The same behavior in the driver
+    //['object', v(new Map<string, any>([['a', 'Hello'], ['b', 1234], ['c', 'World']]), m => Object.fromEntries(m.entries()) )]
+
+    // bytes
+    ['bytes', v(new Uint8Array([0x00, 0x33, 0x66, 0x99, 0xCC, 0xFF]))],
+    
+    // spatial types
+    // the following types is getting bad request
+    // need to double check format
+    // ['WGS Point 2D', v(new Point(int(4326), 1.2, 3.4))],
+    // ['CARTESIAN Point 2D', v(new Point(int(7203), 1.2, 3.4))],
+    // ['WGS Point 3D', v(new Point(int(4979), 1.2, 3.4, 5.6))],
+    // ['CARTESIAN Point 3D', v(new Point(int(9157), 1.2, 3.4, 5.6))],
+
+    // Temporal Types
+    ['Duration', v(new Duration(int(1), int(2), int(30), int(3000)))],
+    ['LocalTime', v(new LocalTime(int(1), int(2), int(20), int(234)))],
+    ['Time', v(new Time(int(1), int(20), int(23), int(234), int(7200)))],
+    ['Date', v(new Date(int(1999), int(6), int(12)))],
+    ['LocalDateTime', v(new LocalDateTime(int(1999), int(6), int(12), int(1), int(2), int(20), int(234)))],
+    ['DateTime', v(new DateTime(int(1999), int(6), int(12), int(1), int(2), int(20), int(234), int(7200), 'Europe/Berlin'))],
+    
+    // Combinations
+    ['nested objects', v(NESTED_OBJECT)],
+    ['list of objects', v(LIST_OF_OBJECTS)],
+    ['object of lists', v(OBJECT_OF_LISTS)]
+  ])('should be able to echo "%s" (%s)', async (_, [input, expectedOutput]) => {
+    const session = wrapper.session({ database: config.database })
+    try {
+      const { records: [first] } = await session.run('RETURN $input as output',  { input })
+      expect(first.get('output')).toEqual(expectedOutput) 
+    } finally {
+      await session.close()
+    }
+  })
+
+  function v<T, K = T>(value: T, mapper: (value: T)=> K = (v) => v as unknown as K): [T, K] {
+    return [value, mapper(value)]
+  }
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES5",
-    "lib": ["ES6"],
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Date types are not being decoded properly and failing with an error. Time types were parsing wrongly milliseconds.
Duration was not handling formats with time.

This errors were find with the minimum functionality integration tests. Theses tests are for testing basic functions in the driver. Problems with the spatial types were also found, but their fix was deferred to another pull request.

Problem with the Map type was also found, but the driver behaves the same.
So, investigation will be needed.

Graph types were not tested yet, but they will in a new PR.

The ESCMAScript version was bumped to 2020 since this version is needed for supporting create bigint as literal.
This doesn't affect the minimal requirements of using the library since Node 18 supports ES2020.