### PR TITLE
Add support for `ResultSummary.plan`

### DIFF
--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -82,7 +82,7 @@ type ProfiledQueryPlan = {
     pageCacheHitRatio: number
     time: number
     operatorType: string
-    arguments: Record<string, unknown>
+    arguments: Record<string, RawQueryValue>
     identifiers: string[]
     children: ProfiledQueryPlan[]
 }
@@ -178,6 +178,8 @@ export class QueryResponseCodec {
                                 break
                             case 'arguments':
                                 actualKey = 'args'
+                                actualValue = Object.fromEntries(Object.entries(value as {})
+                                    .map(([k, v]) => [k, this._decodeValue(v as RawQueryValue)]))
                                 break
                             case 'records':
                                 actualKey = 'row'


### PR DESCRIPTION
This includes a fix in the profile decoder since they underline object is the same. The properties in the arguments weren't being decoded.

Tests for `stats` were also included.

The `withSession` method  was added to the tests to save some boiler plate.