### PR TITLE
Add support to `ResultSummary.profile`

### DIFF
--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -182,7 +182,7 @@ export class QueryResponseCodec {
                                     .map(([k, v]) => [k, this._decodeValue(v as RawQueryValue)]))
                                 break
                             case 'records':
-                                actualKey = 'row'
+                                actualKey = 'rows'
                                 break 
                             default:
                                 break


### PR DESCRIPTION
`records` are translated to rows.