### PR TITLE
Add support to Spatial Types and new values fmt

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "yarn test::unit && yarn test::integration",
     "test::watch": "jest --watch",
     "test::unit": "jest --passWithNoTests",
-    "test::integration": "jest -c jest.integration.config.ts",
+    "test::integration": "jest -c jest.integration.config.ts --passWithNoTests",
     "prepare": "npm run build",
     "clean": "rm -fr node_modules lib types"
   },

--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -51,13 +51,14 @@ export default class HttpConnectionProvider extends ConnectionProvider {
     async acquireConnection(param?: { accessMode?: string | undefined; database?: string | undefined; bookmarks: internal.bookmarks.Bookmarks; impersonatedUser?: string | undefined; onDatabaseNameResolved?: ((databaseName?: string | undefined) => void) | undefined; auth?: types.AuthToken | undefined } | undefined): Promise<Connection & Releasable> {
         const auth = param?.auth ?? await this._authTokenManager.getToken()
         
-        return new HttpConnection({ release: async () => {}, auth, address: this._address, database: (param?.database ?? 'neo4j'), scheme: this._scheme, config: this._config }) 
+        return new HttpConnection({ release: async () => {}, auth, address: this._address, database: (param?.database ?? 'neo4j'), scheme: this._scheme, config: this._config, logger: this._log }) 
     }
 
 
     async verifyConnectivityAndGetServerInfo(param?: { database?: string | undefined; accessMode?: string | undefined } | undefined): Promise<ServerInfo> {
         return new ServerInfo({}, 5.0)
     }
+    
     async close(): Promise<void> {
         
     }

--- a/test/integration/config/index.ts
+++ b/test/integration/config/index.ts
@@ -22,7 +22,7 @@ const username = env.TEST_NEO4J_USER ?? 'neo4j'
 const password = env.TEST_NEO4J_PASS ?? 'password'
 const hostname = env.TEST_NEO4J_HOST ?? 'localhost'
 const scheme = env.TEST_NEO4J_SCHEME ?? 'bolt'
-const version = env.TEST_NEO4J_VERSION ?? '5.21'
+const version = env.TEST_NEO4J_VERSION ?? '5.22'
 const httpPort = env.TEST_NEO4J_HTTP_PORT ?? 7474
 const boltPort = env.TEST_NEO4J_BOLT_PORT ?? 7687
 const edition = env.TEST_NEO4J_EDITION ?? 'enterprise'
@@ -64,5 +64,8 @@ export default {
   },
   async stopNeo4j () {
     await neo4jContainer.stop()
+  },
+  get version (): number {
+    return parseFloat(version)
   }
 }

--- a/test/integration/config/neo4j.container.ts
+++ b/test/integration/config/neo4j.container.ts
@@ -53,7 +53,7 @@ export default class Neo4jContainer {
     let container = new GenericContainer(new DockerImageName(undefined, 'neo4j', tag).toString())
       .withEnv('NEO4J_AUTH', `${this.user}/${this.password}`)
 
-    if (this.edition === 'enterprise') {
+    if (this.edition != null && this.edition.startsWith('enterprise')) {
       container = container.withEnv('NEO4J_ACCEPT_LICENSE_AGREEMENT', 'yes')
     }
 

--- a/test/integration/jest.utils.ts
+++ b/test/integration/jest.utils.ts
@@ -1,0 +1,23 @@
+
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function when (canRun: (() => boolean )| boolean, fn: jest.EmptyFunction ) {
+    if (canRun === true || typeof canRun === 'function' && canRun()) {
+        fn()
+    }
+}


### PR DESCRIPTION
The `POINT` format changed to `WKT` and the values are now return as list of lists instead of a single list.

This new behaviours are breaking change and we need to check they only got run against the correct database version.