### PR TITLE
Remove support for DateTime without offset

### DIFF
--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -739,6 +739,14 @@ export class QueryRequestCodec {
         } else if (isLocalDateTime(value)) {
             return { $type: 'LocalDateTime', _value: value.toString() }
         } else if (isDateTime(value)) {
+            if (value.timeZoneOffsetSeconds == null) {
+                throw new Error(
+                    'DateTime objects without "timeZoneOffsetSeconds" property ' +
+                    'are prune to bugs related to ambiguous times. For instance, ' +
+                    '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.'
+                )
+            }
+            
             if (value.timeZoneId != null) {
                 return { $type: 'ZonedDateTime', _value: value.toString() }
             }

--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -742,7 +742,7 @@ export class QueryRequestCodec {
             if (value.timeZoneOffsetSeconds == null) {
                 throw new Error(
                     'DateTime objects without "timeZoneOffsetSeconds" property ' +
-                    'are prune to bugs related to ambiguous times. For instance, ' +
+                    'are prone to bugs related to ambiguous times. For instance, ' +
                     '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.'
                 )
             }

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -178,7 +178,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
       await expect(session.run(`RETURN $dt`, { dt })).rejects.toEqual(new Error(
         'DateTime objects without "timeZoneOffsetSeconds" property ' +
-                'are prune to bugs related to ambiguous times. For instance, ' +
+                'are prone to bugs related to ambiguous times. For instance, ' +
                 '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.'
       ))
     }

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -190,7 +190,7 @@ describe('QueryRequestCodec', () => {
             })
 
             expect(() => codec.body).toThrow('DateTime objects without "timeZoneOffsetSeconds" property ' +
-                'are prune to bugs related to ambiguous times. For instance, ' +
+                'are prone to bugs related to ambiguous times. For instance, ' +
                 '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.')
         })
 

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -159,8 +159,6 @@ describe('QueryRequestCodec', () => {
             ['Time', v(new Time(12, 50, 35, 556000000, 3600), { $type: 'Time', _value: '12:50:35.556000000+01:00' })],
             ['LocalTime', v(new LocalTime(12, 50, 35, 556000000), { $type: 'LocalTime', _value: '12:50:35.556000000' })],
             ['OffsetDateTime', v(new DateTime(1988, 8, 23, 12, 50, 35, 556000000, -3600), { $type: 'OffsetDateTime', _value: '1988-08-23T12:50:35.556000000-01:00' })],
-            // TODO: FIX
-            // ['ZonedDateTime', v(new DateTime(1988, 8, 23, 12, 50, 35, 556000000, undefined, 'Antarctica/Troll'), { $type: 'ZonedDateTime', _value: '1988-08-23T12:50:35.556000000Z[Antarctica/Troll]' })],
             ['ZonedAndOffsetDateTime', v(new DateTime(1988, 8, 23, 12, 50, 35, 556000000, 3600, 'Antarctica/Troll'), { $type: 'ZonedDateTime', _value: '1988-08-23T12:50:35.556000000+01:00[Antarctica/Troll]' })],
             ['LocalDateTime', v(new LocalDateTime(2001, 5, 3, 13, 45, 0, 3404004), { $type: 'LocalDateTime', _value: '2001-05-03T13:45:00.003404004' })],
             ['Duration', v(new Duration(0, 14, 16, 0), { $type: 'Duration', _value: 'P0M14DT16S' })],
@@ -181,6 +179,19 @@ describe('QueryRequestCodec', () => {
                     param: expected
                 }
             })
+        })
+
+        it('should support DateTime without offset', () => {
+            const param = new DateTime(2024, 3, 31, 2, 30, 0, 0, undefined, 'Europe/Stockholm')
+            const codec = subject({
+                parameters: {
+                    param
+                }
+            })
+
+            expect(() => codec.body).toThrow('DateTime objects without "timeZoneOffsetSeconds" property ' +
+                'are prune to bugs related to ambiguous times. For instance, ' +
+                '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.')
         })
 
         it.each([


### PR DESCRIPTION
The usage of this contruction is prune to errors like ambiguous times. For instance, `2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.`.
And unexisting times like `2024-03-31T02:30:00[Europe/Stockholm`.

The solution is not allowing the user send this kind of DateTime to the server by thrown an exception when serialize it.
This approach is needed because we can't thrown on the DateTime creation since it will configure a breaking change on the driver. This library works slighty different is not an issue since the user need to opt-in to the usage of this new library.