### PR TITLE
Improve memory usage on streamig records

### DIFF
--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -188,9 +188,12 @@ class QuerySuccessResponseCodec extends QueryResponseCodec {
     }
 
     *stream(): Generator<any[]> {
-        for (const value of this._response.data.values) {
-            yield value.map(this._decodeValue.bind(this))
-        }
+        while (this._response.data.values.length > 0) {
+            const value =  this._response.data.values.shift()
+            if (value != null) {
+                yield value.map(this._decodeValue.bind(this))
+            }
+        } 
         return
     }
 

--- a/src/http-connection/stream-observers.ts
+++ b/src/http-connection/stream-observers.ts
@@ -99,9 +99,13 @@ export class ResultStreamObserver implements internal.observer.ResultStreamObser
         }
 
         if (this._queuedRecords.length > 0 && observer.onNext) {
-            for (let i = 0; i < this._queuedRecords.length; i++) {
-                observer.onNext(this._queuedRecords[i])
-                if (this._queuedRecords.length - i - 1 <= this._lowRecordWatermark) {
+            while (this._queuedRecords.length > 0) {
+                const record = this._queuedRecords.shift()
+                if (record != null) {
+                    observer.onNext(record)
+                }
+
+                if (this._queuedRecords.length - 1 <= this._lowRecordWatermark) {
                     this.resume()
                 }
             }

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -1421,6 +1421,9 @@ describe('QueryResponseCodec', () => {
             })
 
             expect([...codec.stream()]).toEqual(expected)
+            // the stream should be consumed,
+            // no data should come after
+            expect([...codec.stream()]).toEqual([])
         })
 
         it.each(

--- a/test/unit/http-connection/stream-observers.test.ts
+++ b/test/unit/http-connection/stream-observers.test.ts
@@ -64,7 +64,7 @@ describe('ResultStreamObserver', () => {
             expect(queuedRecords[3].toObject()).toEqual({ A: 1, B: 2, C: 3 })
         })
 
-        it('passes queued records to a new subscriber', () => {
+        it('should pass queued records to a new subscriber', () => {
             const streamObserver = subject()
             const receivedRecords: Record[] = []
             const resultObserver = observer({
@@ -82,6 +82,30 @@ describe('ResultStreamObserver', () => {
             expect(receivedRecords[0].toObject()).toEqual({ A: 1, B: 2, C: 3 })
             expect(receivedRecords[1].toObject()).toEqual({ A: 11, B: 22, C: 33 })
             expect(receivedRecords[2].toObject()).toEqual({ A: 111, B: 222, C: 333 })
+        })
+
+        it('should clear buffered after redirects to the observer', () => {
+            const streamObserver = subject()
+            const receivedRecords: Record[] = []
+            const receivedRecords2: Record[] = []
+            const resultObserver = observer({
+                onNext: record => receivedRecords.push(record)
+            })
+            const resultObserver2 = observer({
+                onNext: record => receivedRecords2.push(record)
+            })
+
+            streamObserver.onKeys(['A', 'B', 'C'])
+            streamObserver.onNext([1, 2, 3])
+            streamObserver.onNext([11, 22, 33])
+            streamObserver.onNext([111, 222, 333])
+
+            streamObserver.subscribe(resultObserver)
+
+            streamObserver.subscribe(resultObserver2)
+
+            expect(receivedRecords.length).toBe(3)
+            expect(receivedRecords2.length).toBe(0)
         })
     })
 


### PR DESCRIPTION
The wrapper were not discarding after be consumed, which was leading to ineficient memory usage. The wrapper should drop the data after being consumed.