### PR TITLE
Add support for `Wrapper.supportMultiDb()`

### DIFF
--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -97,6 +97,10 @@ export default class HttpConnectionProvider extends ConnectionProvider {
         }, parseFloat(discoveryInfo.version))
     }
 
+    async supportsMultiDb(): Promise<boolean> {
+        return true
+    }
+
     async close(): Promise<void> {
         await this._pool.close()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ type WrapperSession = Pick<Session, 'run' | 'lastBookmarks' | 'close' > & Dispos
 type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode'> & {
   database: string
 }
-type Wrapper = Pick<Driver, 'close' > & Disposable & VerifyConnectivity & {
+type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb' > & Disposable & VerifyConnectivity & {
   session(config: WrapperSessionConfig): WrapperSession
 } 
 

--- a/src/wrapper.impl.ts
+++ b/src/wrapper.impl.ts
@@ -31,6 +31,10 @@ export class WrapperImpl implements Wrapper {
         validateDatabase(config)
         return this.driver.verifyConnectivity(config)
     }
+
+    supportsMultiDb(): Promise<boolean> {
+        return this.driver.supportsMultiDb()
+    }
     
     [Symbol.asyncDispose](): Promise<void> {
         return this.driver.close()

--- a/test/unit/http-connection/connection-provider.http.test.ts
+++ b/test/unit/http-connection/connection-provider.http.test.ts
@@ -15,20 +15,15 @@
  * limitations under the License.
  */
 
-import HttpConnectionProvider, { 
-    HttpConnectionProviderInjectable, 
-    HttpConnectionProviderConfig 
-} from '../../../src/http-connection/connection-provider.http'
+import HttpConnectionProvider from '../../../src/http-connection/connection-provider.http'
 
-import { auth, authTokenManagers, internal, newError, staticAuthTokenManager } from "neo4j-driver-core"
+import { auth, internal, newError, staticAuthTokenManager } from "neo4j-driver-core"
 import HttpConnection, { HttpScheme } from '../../../src/http-connection/connection.http'
-import { logging } from '../../../src'
 
 type NewPool = (...params: ConstructorParameters<typeof internal.pool.Pool<HttpConnection>>) => internal.pool.Pool<HttpConnection>
 
 
 describe('HttpConnectionProvider', () => {
-
     describe('pool configuration', () => {
         describe('create', () => {
             it('should create a connection and register in the open connections', async () => {
@@ -275,6 +270,15 @@ describe('HttpConnectionProvider', () => {
 
                 expect(connection.auth).not.toEqual(newAuth)
             })
+        })
+    })
+
+    describe('.supportsMultiDb()', () => {
+        it ('should resolves true', async () => {
+            const address = internal.serverAddress.ServerAddress.fromUrl('localhost:7474')
+            const { provider } = newProvider(address, jest.fn())
+
+            await expect(provider.supportsMultiDb()).resolves.toBe(true)
         })
     })
 })

--- a/test/unit/wrapper.impl.test.ts
+++ b/test/unit/wrapper.impl.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { newError, ConnectionProvider, Driver, internal } from 'neo4j-driver-core'
+import { Logger, Wrapper } from '../../src'
+import { WrapperImpl } from '../../src/wrapper.impl'
+
+
+describe('Wrapper', () => {
+    let connectionProvider: ConnectionProvider
+    let wrapper: Wrapper | null
+    const META_INFO = {
+        routing: false,
+        typename: '',
+        address: 'localhost'
+    }
+    const CONFIG = {}
+
+    beforeEach(() => {
+        connectionProvider = new ConnectionProvider()
+        connectionProvider.close = jest.fn(() => Promise.resolve())
+
+
+        const driver = new Driver(
+            META_INFO,
+            CONFIG,
+            mockCreateConnectionProvider(connectionProvider),
+        )
+
+        wrapper = new WrapperImpl(driver)
+    })
+
+    afterEach(async () => {
+        if (wrapper != null) {
+            await wrapper.close()
+            wrapper = null
+        }
+    })
+
+
+    it.each([
+        ['Promise.resolve(true)', Promise.resolve(true)],
+        ['Promise.resolve(false)', Promise.resolve(false)],
+        [
+            "Promise.reject(newError('something went wrong'))",
+            Promise.reject(newError('something went wrong'))
+        ]
+    ])('.supportsMultiDb() => %s', (_, expectedPromise) => {
+        connectionProvider.supportsMultiDb = jest.fn(() => expectedPromise)
+
+        const promise: Promise<boolean> | undefined = wrapper?.supportsMultiDb()
+
+        expect(promise).toBe(expectedPromise)
+
+        promise?.catch(_ => 'Do nothing').finally(() => { })
+    })
+
+    function mockCreateConnectionProvider(connectionProvider: ConnectionProvider) {
+        return (
+            id: number,
+            config: Object,
+            log: Logger,
+            hostNameResolver: internal.resolver.ConfiguredCustomResolver
+        ) => connectionProvider
+    }
+})


### PR DESCRIPTION
This method should always return true since the QueryApi is only accepted in databases which has support for multi-db.