### PR TITLE
Check auth on `Wrapper.verifyConnectivity`

### DIFF
--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -95,7 +95,7 @@ export default class HttpConnection extends Connection {
             then(async (res) => {
                 return [res.headers.get('content-type'), (await res.json()) as RawQueryResponse]
             })
-            .catch(this._handleAndReThrown.bind(this))
+            .catch((error) => this._handleAndReThrown(newError(`Failure accessing "${request.url}"`, 'SERVICE_UNAVAILABLE', error)))
             .catch((error) => observer.onError(error))
             .then(async ([contentType, rawQueryResponse]: [string, RawQueryResponse]) => {
                 if (rawQueryResponse == null) {
@@ -181,6 +181,14 @@ export default class HttpConnection extends Connection {
 
     get auth(): types.AuthToken {
         return this._auth
+    }
+
+    set queryEndpoint(queryEndpoint: string) {
+        this._queryEndpoint = queryEndpoint
+    }
+
+    get queryEndpoint(): string {
+        return this._queryEndpoint
     }
 
     getProtocolVersion(): number {

--- a/test/unit/wrapper.impl.test.ts
+++ b/test/unit/wrapper.impl.test.ts
@@ -68,6 +68,23 @@ describe('Wrapper', () => {
         promise?.catch(_ => 'Do nothing').finally(() => { })
     })
 
+    it.each([
+        ['Promise.resolve(object)', Promise.resolve({ })],
+        [
+            "Promise.reject(newError('something went wrong on verify conn'))",
+            Promise.reject(newError('something went wrong on verify conn'))
+        ]
+    ])('.verifyConnectivity() => %s', (_, expectedPromise) => {
+        connectionProvider.verifyConnectivityAndGetServerInfo = jest.fn(() => expectedPromise)
+        const config = { database: 'db' }
+
+        const promise: Promise<any> | undefined = wrapper?.verifyConnectivity(config)
+
+        expect(promise).toBe(expectedPromise)
+        expect(connectionProvider.verifyConnectivityAndGetServerInfo).toHaveBeenCalledWith({ ...config, accessMode: 'READ' })
+        promise?.catch(_ => 'Do nothing').finally(() => { })
+    })
+
     function mockCreateConnectionProvider(connectionProvider: ConnectionProvider) {
         return (
             id: number,


### PR DESCRIPTION
The driver version of the method fails on invalid creadentials, so this also have to do it for better interchangeable usage.

In the case of the Wrapper, a query might be run for verifying if the database can handle requests from the driver credentials.

Along with this changes, other changes related to the endpoint configuration were also done so the rediscovery get triggered when endpoint is not accessible.