### PR TITLE
Enabling user to change auth for a session

### DIFF
--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -139,6 +139,14 @@ export default class HttpConnectionProvider extends ConnectionProvider {
         return true
     }
 
+    async supportsSessionAuth(): Promise<boolean> {
+        return true
+    }
+
+    async supportsUserImpersonation(): Promise<boolean> {
+        return true
+    }
+
     async close(): Promise<void> {
         await this._pool.close()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,10 +23,10 @@ type VerifyConnectivity = {
 
 type HttpUrl = `http://${string}` | `https://${string}`
 type WrapperSession = Pick<Session, 'run' | 'lastBookmarks' | 'close' > & Disposable 
-type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode'> & {
+type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode' | 'auth'> & {
   database: string
 }
-type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb' > & Disposable & VerifyConnectivity & {
+type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb' | 'supportsSessionAuth' | 'supportsUserImpersonation'> & Disposable & VerifyConnectivity & {
   session(config: WrapperSessionConfig): WrapperSession
 } 
 

--- a/src/wrapper.impl.ts
+++ b/src/wrapper.impl.ts
@@ -36,15 +36,23 @@ export class WrapperImpl implements Wrapper {
         return this.driver.supportsMultiDb()
     }
     
-    [Symbol.asyncDispose](): Promise<void> {
-        return this.driver.close()
+    supportsSessionAuth(): Promise<boolean> {
+        return this.driver.supportsSessionAuth()
     }
 
+    supportsUserImpersonation(): Promise<boolean> {
+        return this.driver.supportsUserImpersonation()
+    }
+    
     session (config: WrapperSessionConfig): WrapperSession {
         validateDatabase(config);
-
+        
         const session = this.driver.session(config)
         return new WrapperSessionImpl(session)
+    }
+
+    [Symbol.asyncDispose](): Promise<void> {
+        return this.driver.close()
     }
 }
 

--- a/test/integration/config/stubs/session_run_bearer_token_impersonated_return_1.stub.json
+++ b/test/integration/config/stubs/session_run_bearer_token_impersonated_return_1.stub.json
@@ -1,0 +1,67 @@
+{
+    "request": {
+        "method": "POST",
+        "url": "/db/neo4j/query/v2",
+        "headers": {
+            "Content-Type": {
+                "equalTo": "application/vnd.neo4j.query"
+            },
+            "Accept": {
+                "equalTo": "application/vnd.neo4j.query, application/json"
+            },
+            "Authorization": {
+                "equalTo": "Bearer bmljZXN0VG9rZW5FdmVy"
+            }
+        },
+        "bodyPatterns": [
+            {
+                "equalToJson": {
+                    "statement": "RETURN 1",
+                    "includeCounters": true,
+                    "accessMode": "WRITE",
+                    "impersonatedUser": "the_imposter"
+                }
+            }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "body": {
+            "data": {
+                "fields": [
+                    "1"
+                ],
+                "values": [
+                    [
+                        {
+                            "$type": "Integer",
+                            "_value": "1"
+                        }
+                    ]
+                ]
+            },
+            "counters": {
+                "containsUpdates": false,
+                "nodesCreated": 0,
+                "nodesDeleted": 0,
+                "propertiesSet": 0,
+                "relationshipsCreated": 0,
+                "relationshipsDeleted": 0,
+                "labelsAdded": 0,
+                "labelsRemoved": 0,
+                "indexesAdded": 0,
+                "indexesRemoved": 0,
+                "constraintsAdded": 0,
+                "constraintsRemoved": 0,
+                "containsSystemUpdates": false,
+                "systemUpdates": 0
+            },
+            "bookmarks": [
+                "FB:kcwQUln6E/U2SUyIXRY1rTIt8wKQ"
+            ]
+        },
+        "headers": {
+            "Content-Type": "application/vnd.neo4j.query"
+        }
+    }
+}

--- a/test/integration/minimum.stub.test.ts
+++ b/test/integration/minimum.stub.test.ts
@@ -51,7 +51,37 @@ describe('minimum requirements stub', () => {
         for await (const session of withSession(wrapper, { database: 'neo4j' })) {
             await expect(session.run('RETURN 1')).resolves.toBeDefined()
         }
+    })
 
+    it('should support session auth', async () => {
+        localMocks.push(
+            await config.loadWireMockStub('session_run_bearer_token_return_1')
+        )
+
+        const wrapper = neo4j.wrapper(
+            `http://${config.hostname}:${config.wireMockPort}`,
+            // this auth doesn't work
+            neo4j.auth.basic('neo4j', 'password')
+        )
+
+        for await (const session of withSession(wrapper, { database: 'neo4j', auth: neo4j.auth.bearer('nicestTokenEver') })) {
+            await expect(session.run('RETURN 1')).resolves.toBeDefined()
+        }
+    })
+
+    it('should support impersonation', async () => {
+        localMocks.push(
+            await config.loadWireMockStub('session_run_bearer_token_impersonated_return_1')
+        )
+
+        const wrapper = neo4j.wrapper(
+            `http://${config.hostname}:${config.wireMockPort}`,
+            neo4j.auth.bearer('nicestTokenEver')
+        )
+
+        for await (const session of withSession(wrapper, { database: 'neo4j', impersonatedUser: 'the_imposter' })) {
+            await expect(session.run('RETURN 1')).resolves.toBeDefined()
+        }
     })
 
 })

--- a/test/unit/http-connection/connection-provider.http.test.ts
+++ b/test/unit/http-connection/connection-provider.http.test.ts
@@ -333,6 +333,24 @@ describe('HttpConnectionProvider', () => {
         })
     })
 
+    describe('.supportsUserImpersonation()', () => {
+        it ('should resolves true', async () => {
+            const address = internal.serverAddress.ServerAddress.fromUrl('localhost:7474')
+            const { provider } = newProvider(address)
+
+            await expect(provider.supportsUserImpersonation()).resolves.toBe(true)
+        })
+    })
+
+    describe('.supportsSessionAuth()', () => {
+        it ('should resolves true', async () => {
+            const address = internal.serverAddress.ServerAddress.fromUrl('localhost:7474')
+            const { provider } = newProvider(address)
+
+            await expect(provider.supportsSessionAuth()).resolves.toBe(true)
+        })
+    })
+
     describe.each(['READ', 'WRITE'].flatMap(mode => [
         ['neo4j', mode],
         ['system', mode],


### PR DESCRIPTION
This also enables support for the helper methods `supportsSessionAuth` and `supportsUserImpersonation`.
Those method should always return true since they are supported by the query api.

Tests were added for impersonation, since the feature was implemented, but not test were done.