### PR TITLE
Add support for `verifyAuthentication`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Driver, Session, SessionConfig, Config, ServerInfo } from "neo4j-driver-core"
+import { Driver, Session, SessionConfig, Config, ServerInfo, types } from "neo4j-driver-core"
 
 type Disposable = { [Symbol.asyncDispose] (): Promise<void> }
 type VerifyConnectivity = { 
   verifyConnectivity(config: { database: string | undefined; } | undefined): Promise<ServerInfo>
+}
+
+type VerifyAuthentication = {
+  verifyAuthentication(config: { auth?: types.AuthToken | undefined; database: string; }): Promise<boolean>
 }
 
 type HttpUrl = `http://${string}` | `https://${string}`
@@ -26,7 +30,7 @@ type WrapperSession = Pick<Session, 'run' | 'lastBookmarks' | 'close' > & Dispos
 type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode' | 'auth'> & {
   database: string
 }
-type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb' | 'supportsSessionAuth' | 'supportsUserImpersonation'> & Disposable & VerifyConnectivity & {
+type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb'| 'supportsSessionAuth' | 'supportsUserImpersonation'> & Disposable & VerifyConnectivity & VerifyAuthentication & {
   session(config: WrapperSessionConfig): WrapperSession
 } 
 

--- a/src/wrapper.impl.ts
+++ b/src/wrapper.impl.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Driver, ServerInfo } from "neo4j-driver-core";
+import { Driver, ServerInfo, types } from "neo4j-driver-core";
 import { Wrapper, WrapperSession, WrapperSessionConfig } from "./types";
 import WrapperSessionImpl from "./wrapper-session.impl";
 
@@ -34,6 +34,12 @@ export class WrapperImpl implements Wrapper {
 
     supportsMultiDb(): Promise<boolean> {
         return this.driver.supportsMultiDb()
+    }
+
+    verifyAuthentication(config: { auth?: types.AuthToken | undefined; database: string; }): Promise<boolean> {
+        validateDatabase(config)
+
+        return this.driver.verifyAuthentication(config)
     }
     
     supportsSessionAuth(): Promise<boolean> {


### PR DESCRIPTION
This is usefull method for using when a user checking if a user auth token is valid or not.

This method should only be used if `driver.supportSessionAuth()` resolves true, this should be always the case for this Wrapper.