### PR TITLE
Fix verifyConnectivity and verifyAuthentication on system db

### DIFF
--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -227,7 +227,7 @@ export default class HttpConnectionProvider extends ConnectionProvider {
  */
 function run(connection: Connection, config: { database: string; accessMode?: string | undefined } | undefined): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-        connection.run('RETURN 1', {}, {
+        connection.run('CALL db.ping()', {}, {
             database: config?.database, mode: config?.accessMode as AccessMode, fetchSize: 200, reactive: false, bookmarks: Bookmarks.empty(), highRecordWatermark: 10, lowRecordWatermark: 0, txConfig: TxConfig.empty()
         })
             .subscribe({

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -91,8 +91,11 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     await wrapper?.close()
   })
 
-  it('should verifyConnectivity', async () => {
-    await expect(wrapper.verifyConnectivity({ database: config.database })).resolves.toBeDefined()
+  it.each([
+    [config.database],
+    ['system']
+  ])('should verifyConnectivity ({ database: "%s"})', async (database) => {
+    await expect(wrapper.verifyConnectivity({ database })).resolves.toBeDefined()
   })
 
   it.each([

--- a/test/unit/http-connection/connection-provider.http.test.ts
+++ b/test/unit/http-connection/connection-provider.http.test.ts
@@ -359,7 +359,7 @@ describe('HttpConnectionProvider', () => {
     ]))('.verifyConnectivityAndGetServerInfo({ database: "%s", accessMode: "%"})', (database, accessMode) => {
         const address = internal.serverAddress.ServerAddress.fromUrl('localhost:7474')
         
-        it('should be able to acquire a new connection and run "RETURN 1" using access mode', async () => {    
+        it('should be able to acquire a new connection and run "CALL db.ping()" using access mode', async () => {    
             // Setting up state holders
             const { newHttpConnection, discoverSpy, spyOnRunners, spyOnRelease } = setupSpies(address)
 
@@ -388,7 +388,7 @@ describe('HttpConnectionProvider', () => {
                 queryEndpoint: expectedQueryApi
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -425,7 +425,7 @@ describe('HttpConnectionProvider', () => {
                 queryEndpoint: expectedQueryApi
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -470,7 +470,7 @@ describe('HttpConnectionProvider', () => {
                 queryEndpoint: expectedQueryApi
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -539,7 +539,7 @@ describe('HttpConnectionProvider', () => {
                 auth: auth ?? await authTokenManager.getToken()
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -577,7 +577,7 @@ describe('HttpConnectionProvider', () => {
                 auth: auth ?? await authTokenManager.getToken()
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -630,7 +630,7 @@ describe('HttpConnectionProvider', () => {
                 auth: auth ?? authTokenManager.getToken()
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))
@@ -680,7 +680,7 @@ describe('HttpConnectionProvider', () => {
                 auth: auth ?? authTokenManager.getToken()
             }))
             expect(spyOnRunners[0]).toHaveBeenCalledTimes(1)
-            expect(spyOnRunners[0]).toHaveBeenCalledWith('RETURN 1', {}, expect.objectContaining({
+            expect(spyOnRunners[0]).toHaveBeenCalledWith('CALL db.ping()', {}, expect.objectContaining({
                 database,
                 mode: accessMode
             }))


### PR DESCRIPTION
The system database doesn't support run queries like `RETURN 1`, so those methods are failing when configured with it.

For solving those problems, the query `CALL db.ping()` is used instead. This query should run in any database without problems.