### PR TITLE
Add support to explicit transactions

### DIFF
--- a/src/http-connection/codec.ts
+++ b/src/http-connection/codec.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { types } from "neo4j-driver-core"
+import { BeginTransactionConfig } from "neo4j-driver-core/types/connection"
+
+
+export const NEO4J_QUERY_CONTENT_TYPE = 'application/vnd.neo4j.query'
+
+export function encodeAuthToken(auth: types.AuthToken): string {
+    switch (auth.scheme) {
+        case 'bearer':
+            return `Bearer ${btoa(auth.credentials)}`
+        case 'basic':
+            return `Basic ${btoa(`${auth.principal}:${auth.credentials}`)}`
+        default:
+            throw new Error(`Authorization scheme "${auth.scheme}" is not supported.`)
+    }
+}
+
+export function encodeTransactionBody (config?: Pick<BeginTransactionConfig, 'bookmarks' | 'txConfig' | 'mode' | 'impersonatedUser'> ): Record<string, unknown> {
+    const body: Record<string, unknown> = {} 
+
+    if (config?.bookmarks != null && !config.bookmarks.isEmpty()) {
+        body.bookmarks = config?.bookmarks?.values()
+    }
+
+    if (config?.txConfig.timeout != null) {
+        body.maxExecutionTime = config?.txConfig.timeout.toInt()
+    }
+
+    if (config?.impersonatedUser != null) {
+        body.impersonatedUser = config?.impersonatedUser
+    }
+
+    if (config?.mode) {
+        body.accessMode = config.mode.toUpperCase()
+    }
+
+    return body
+}

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -445,8 +445,10 @@ export default class HttpConnection extends Connection {
 
 async function readBodyAndReaders<T extends Record<string, unknown>> (url: string, response: Response, ...headers: string[]): Promise<{ body: T, headers: (string | null)[]}> {
     try {
+        const text = await response.text()
+        
         return {
-            body: await response.json() as T,
+            body: text !== '' ? JSON.parse(text) : {},
             headers: headers.map(header => response.headers.get(header))
         }        
     } catch (error) {

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -243,6 +243,7 @@ export default class HttpConnection extends Connection {
                 mode: 'cors',
                 headers: this._headers(requestCodec),
                 signal: abortController.signal,
+                body: JSON.stringify(requestCodec.body)
             }
     
             this._log?.debug(`${this} REQUEST: ${JSON.stringify(request)} `)
@@ -296,6 +297,7 @@ export default class HttpConnection extends Connection {
                 mode: 'cors',
                 headers: this._headers(requestCodec),
                 signal: abortController.signal,
+                body: JSON.stringify(requestCodec.body)
             }
     
             this._log?.debug(`${this} REQUEST: ${JSON.stringify(request)} `)

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -145,7 +145,7 @@ export default class HttpConnection extends Connection {
                 .finally(() => {
                     this._abortController = undefined
                 })
-        })
+        }).catch(error => observer.onError(error))
 
         return observer
     }
@@ -233,7 +233,7 @@ export default class HttpConnection extends Connection {
                 .finally(() => {
                     this._abortController = undefined
                 })
-        })
+        }).catch(error => observer.onError(error))
 
 
         return observer
@@ -299,8 +299,7 @@ export default class HttpConnection extends Connection {
                 .finally(() => {
                     this._abortController = undefined
                 })
-
-        })
+        }).catch(error => observer.onError(error))
 
         
 
@@ -367,7 +366,7 @@ export default class HttpConnection extends Connection {
                 .finally(() => {
                     this._abortController = undefined
                 })
-        })
+        }).catch(error => observer.onError(error))
 
         return observer
     }

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -50,7 +50,7 @@ export default class HttpConnection extends Connection {
     private _id: number
     private _errorHandler: (error: Error & { code: string, retriable: boolean }) => Error
     private _open: boolean
-    private _currentTx: { id: string, affinity?: string, host?: string, database: string } | undefined
+    private _currentTx: { id: string, affinity?: string, host?: string, expires: Date,  database: string } | undefined
     private _workPipe: Pipe
 
     constructor(config: HttpConnectionConfig) {
@@ -202,6 +202,7 @@ export default class HttpConnection extends Connection {
             this._currentTx = {
                 id: codec.id,
                 host: codec.host,
+                expires: codec.expires,
                 database: config?.database!,
             }
 

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -50,7 +50,7 @@ export default class HttpConnection extends Connection {
     private _id: number
     private _errorHandler: (error: Error & { code: string, retriable: boolean }) => Error
     private _open: boolean
-    private _currentTx: { id: string, affinity?: string, host: string, database: string } | undefined
+    private _currentTx: { id: string, affinity?: string, host?: string, database: string } | undefined
     private _workPipe: Pipe
 
     constructor(config: HttpConnectionConfig) {
@@ -137,7 +137,11 @@ export default class HttpConnection extends Connection {
         return observer
     }
 
-    private _headers(requestCodec: any) {
+    private _headers(requestCodec: {
+        contentType: string,
+        accept: string,
+        authorization: string
+    }) {
         const headers: Record<string, string | ReadonlyArray<string>>  = {
             'Content-Type': requestCodec.contentType,
             Accept: requestCodec.accept,

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -19,7 +19,7 @@ import { Connection, types, internal, newError } from "neo4j-driver-core"
 import { BeginTransactionConfig, CommitTransactionConfig, RunQueryConfig } from "neo4j-driver-core/types/connection"
 import { ResultStreamObserver } from "./stream-observers"
 import { QueryRequestCodec, QueryResponseCodec, RawQueryResponse } from "./query.codec"
-import { BeginTransactionRequestCodec, BeginTransactionResponse, BeginTransactionResponseCodec, CommitTransactionRequestCodec, CommitTransactionResponse, CommitTransactionResponseCodec, RollbackTransactionRequestCodec, RollbackTransactionResponse, RollbackTransactionResponseCodec } from "./transaction.codec"
+import { BeginTransactionRequestCodec, RawBeginTransactionResponse, BeginTransactionResponseCodec, CommitTransactionRequestCodec, RawCommitTransactionResponse, CommitTransactionResponseCodec, RollbackTransactionRequestCodec, RawRollbackTransactionResponse, RollbackTransactionResponseCodec } from "./transaction.codec"
 import { WrapperConfig } from "../types"
 import Pipe from "./lang/pipe"
 
@@ -189,13 +189,13 @@ export default class HttpConnection extends Connection {
             const {
                 body: rawBeginTransactionResponse,
                 headers: [contentType, affinity]
-            } = await readBodyAndReaders<BeginTransactionResponse>(request.url, res, 'content-type', this._sessionAffinityHeader)
+            } = await readBodyAndReaders<RawBeginTransactionResponse>(request.url, res, 'content-type', this._sessionAffinityHeader)
 
             this._log?.debug(`${this} ${JSON.stringify(rawBeginTransactionResponse)}`)
             
             const codec = BeginTransactionResponseCodec.of(this._config, contentType ?? '', rawBeginTransactionResponse);
 
-            if (codec.error) {
+            if (codec.error != null) {
                 throw codec.error
             }
 
@@ -252,7 +252,7 @@ export default class HttpConnection extends Connection {
             const {
                 body: rawCommitTransactionResponse,
                 headers: [contentType]
-            } = await readBodyAndReaders<CommitTransactionResponse>(request.url, res, 'contentType')
+            } = await readBodyAndReaders<RawCommitTransactionResponse>(request.url, res, 'contentType')
 
             this._log?.debug(`${this} ${JSON.stringify(rawCommitTransactionResponse)}`)
             
@@ -308,7 +308,7 @@ export default class HttpConnection extends Connection {
                 headers: [
                     contentType
                 ]
-            } = await readBodyAndReaders<RollbackTransactionResponse>(request.url, res, 'content-type')
+            } = await readBodyAndReaders<RawRollbackTransactionResponse>(request.url, res, 'content-type')
 
             this._log?.debug(`${this} ${JSON.stringify(rawRollbackTransactionResponse)}`)
             

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -333,12 +333,10 @@ export default class HttpConnection extends Connection {
         if (this._currentTx === undefined) {
             return this._queryEndpoint.replace('{databaseName}', database)
         }
-        // TODO: ADD HOST
         return this._queryEndpoint.replace('{databaseName}',  this._currentTx.database) + `tx/${this._currentTx.id}`
     }
 
     private _getTransactionCommitApi(): string {
-        // TODO: ADD HOST
         return this._queryEndpoint.replace('{databaseName}', this._currentTx?.database!) + `tx/${this._currentTx?.id}/commit`
     }
 
@@ -360,7 +358,6 @@ export default class HttpConnection extends Connection {
             .then(json => {
                 if (typeof json.query !== 'string') {
                     throw new Error('Query API is not available')
-
                 }
                 return { query: json.query, version: json.neo4j_version, edition: json.neo4j_edition }
             })

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -74,6 +74,7 @@ export default class HttpConnection extends Connection {
             highRecordWatermark: config?.highRecordWatermark ?? Number.MAX_SAFE_INTEGER,
             lowRecordWatermark: config?.lowRecordWatermark ?? Number.MIN_SAFE_INTEGER,
             afterComplete: config?.afterComplete,
+            beforeError: config?.beforeError,
             server: this._address,
         })
 
@@ -154,6 +155,7 @@ export default class HttpConnection extends Connection {
         const observer = new ResultStreamObserver({
             server: this._address,
             afterComplete: config?.afterComplete,
+            beforeError: config.beforeError,
             highRecordWatermark: Number.MAX_SAFE_INTEGER,
             lowRecordWatermark: Number.MIN_SAFE_INTEGER,
           })
@@ -216,6 +218,7 @@ export default class HttpConnection extends Connection {
         const observer = new ResultStreamObserver({
             server: this._address,
             afterComplete: config?.afterComplete,
+            beforeError: config.beforeError,
             highRecordWatermark: Number.MAX_SAFE_INTEGER,
             lowRecordWatermark: Number.MIN_SAFE_INTEGER,
           })
@@ -268,6 +271,7 @@ export default class HttpConnection extends Connection {
         const observer = new ResultStreamObserver({
             server: this._address,
             afterComplete: config?.afterComplete,
+            beforeError: config.beforeError,
             highRecordWatermark: Number.MAX_SAFE_INTEGER,
             lowRecordWatermark: Number.MIN_SAFE_INTEGER,
           })
@@ -318,26 +322,21 @@ export default class HttpConnection extends Connection {
         return observer
     }
 
-    private _handleAndReThrown(error: Error & { code: string, retriable: boolean }): Error {
-        this._currentTx = undefined
-        throw this._errorHandler(error)
-    }
-
     private _getTransactionApi(database: string): string {
         if (this._currentTx === undefined) {
             return this._queryEndpoint.replace('{databaseName}', database)
         }
         // TODO: ADD HOST
-        return this._queryEndpoint.replace('{databaseName}',  this._currentTx.database) + `/tx/${this._currentTx.id}`
+        return this._queryEndpoint.replace('{databaseName}',  this._currentTx.database) + `tx/${this._currentTx.id}`
     }
 
     private _getTransactionCommitApi(): string {
         // TODO: ADD HOST
-        return this._queryEndpoint.replace('{databaseName}', this._currentTx?.database!) + `/tx/${this._currentTx?.id}/commit`
+        return this._queryEndpoint.replace('{databaseName}', this._currentTx?.database!) + `tx/${this._currentTx?.id}/commit`
     }
 
     private _getExplicityTransactionApi(database: string): string {
-        return this._queryEndpoint.replace('{databaseName}', database) + '/tx'
+        return this._queryEndpoint.replace('{databaseName}', database) + 'tx'
     }
 
     static async discover({ scheme, address }: { scheme: HttpScheme, address: internal.serverAddress.ServerAddress }): Promise<{

--- a/src/http-connection/connection.http.ts
+++ b/src/http-connection/connection.http.ts
@@ -333,15 +333,15 @@ export default class HttpConnection extends Connection {
         if (this._currentTx === undefined) {
             return this._queryEndpoint.replace('{databaseName}', database)
         }
-        return this._queryEndpoint.replace('{databaseName}',  this._currentTx.database) + `tx/${this._currentTx.id}`
+        return this._queryEndpoint.replace('{databaseName}',  this._currentTx.database) + `/tx/${this._currentTx.id}`
     }
 
     private _getTransactionCommitApi(): string {
-        return this._queryEndpoint.replace('{databaseName}', this._currentTx?.database!) + `tx/${this._currentTx?.id}/commit`
+        return this._queryEndpoint.replace('{databaseName}', this._currentTx?.database!) + `/tx/${this._currentTx?.id}/commit`
     }
 
     private _getExplicityTransactionApi(database: string): string {
-        return this._queryEndpoint.replace('{databaseName}', database) + 'tx'
+        return this._queryEndpoint.replace('{databaseName}', database) + '/tx'
     }
 
     static async discover({ scheme, address }: { scheme: HttpScheme, address: internal.serverAddress.ServerAddress }): Promise<{
@@ -359,7 +359,8 @@ export default class HttpConnection extends Connection {
                 if (typeof json.query !== 'string') {
                     throw new Error('Query API is not available')
                 }
-                return { query: json.query, version: json.neo4j_version, edition: json.neo4j_edition }
+                const query = json.query.endsWith('/') ? json.query.substring(0, json.query.length - 1) : json.query
+                return { query, version: json.neo4j_version, edition: json.neo4j_edition }
             })
             .catch(e => {
                 throw newError(`Failure discovering endpoints. Caused by: ${e.message}`, 'SERVICE_UNAVAILABLE', e)

--- a/src/http-connection/lang/pipe.ts
+++ b/src/http-connection/lang/pipe.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { internal } from "neo4j-driver-core"
+
+export default class Pipe {
+    private promise: Promise<void>
+
+    constructor(private logger?: internal.logger.Logger) {
+        this.promise = Promise.resolve()
+    }
+
+    attach (work: () => Promise<void> | void): Promise<void> {
+        this.promise =  this.promise.then(work)
+        return this.promise
+    }
+
+    recover (): void {
+        this.promise = this.promise.catch(error => {
+            if (this.logger?.isDebugEnabled() === true) {
+                this.logger?.debug(`Recovering from ${error}`)
+            }
+        })
+    }
+}

--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -677,8 +677,6 @@ export class QueryRequestCodec {
 
     }
 
-
-
     get contentType(): string {
         return NEO4J_QUERY_CONTENT_TYPE
     }

--- a/src/http-connection/query.codec.ts
+++ b/src/http-connection/query.codec.ts
@@ -17,6 +17,7 @@
 
 import { newError, Node, Relationship, int, error, types, Integer, Time, Date, LocalTime, Point, DateTime, LocalDateTime, Duration, isInt, isPoint, isDuration, isLocalTime, isTime, isDate, isLocalDateTime, isDateTime, isRelationship, isPath, isNode, isPathSegment, Path, PathSegment, internal, isUnboundRelationship } from "neo4j-driver-core"
 import { RunQueryConfig } from "neo4j-driver-core/types/connection"
+import { NEO4J_QUERY_CONTENT_TYPE, encodeAuthToken, encodeTransactionBody } from "./codec"
 
 export type RawQueryValueTypes = 'Null' | 'Boolean' | 'Integer' | 'Float' | 'String' |
     'Time' | 'Date' | 'LocalTime' | 'ZonedDateTime' | 'OffsetDateTime' | 'LocalDateTime' |
@@ -125,8 +126,6 @@ export type RawQueryFailuresResponse = {
 }
 
 export type RawQueryResponse = RawQuerySuccessResponse | RawQueryFailuresResponse
-
-const NEO4J_QUERY_CONTENT_TYPE = 'application/vnd.neo4j.query'
 
 export class QueryResponseCodec {
 
@@ -686,14 +685,7 @@ export class QueryRequestCodec {
     }
 
     get authorization(): string {
-        switch (this._auth.scheme) {
-            case 'bearer':
-                return `Bearer ${btoa(this._auth.credentials)}`
-            case 'basic':
-                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
-            default:
-                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
-        }
+        return encodeAuthToken(this._auth)
     }
 
     get body(): Record<string, unknown> {
@@ -703,27 +695,12 @@ export class QueryRequestCodec {
 
         this._body = {
             statement: this._query,
-            includeCounters: true
+            includeCounters: true,
+            ...encodeTransactionBody(this._config)
         }
 
         if (this._parameters != null && Object.getOwnPropertyNames(this._parameters).length !== 0) {
             this._body.parameters = this._encodeParameters(this._parameters!)
-        }
-
-        if (this._config?.bookmarks != null && !this._config.bookmarks.isEmpty()) {
-            this._body.bookmarks = this._config?.bookmarks?.values()
-        }
-
-        if (this._config?.txConfig.timeout != null) {
-            this._body.maxExecutionTime = this._config?.txConfig.timeout.toInt()
-        }
-
-        if (this._config?.impersonatedUser != null) {
-            this._body.impersonatedUser = this._config?.impersonatedUser
-        }
-
-        if (this._config?.mode) {
-            this._body.accessMode = this._config.mode.toUpperCase()
         }
 
         return this._body

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -25,7 +25,7 @@ export type RollbackTransactionRequestCodecConfig = {}
 
 export type RawTransaction = {
     id: string
-    expires: number
+    expires: string
     tx_host?: string
 }
 
@@ -112,7 +112,7 @@ export class BeginTransactionResponseCodec {
         throw new Error('Not implemented')
     }
 
-    get expires(): number {
+    get expires(): Date {
         throw new Error('Not implemented')
     }
 
@@ -137,8 +137,8 @@ class  BeginTransactionSuccessResponseCodec extends BeginTransactionResponseCode
         return this._response.transaction.id
     }
 
-    get expires(): number {
-        return this._response.transaction.expires
+    get expires(): Date {
+        return new Date(this._response.transaction.expires)
     }
 
     get host(): string | undefined {
@@ -159,7 +159,7 @@ class BeginTransactionFailureResponseCodec extends BeginTransactionResponseCodec
         throw this._error
     }
 
-    get expires(): number {
+    get expires(): Date {
         throw this._error
     }
 

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -28,7 +28,7 @@ export type RollbackTransactionRequestCodecConfig = {}
 export type RawTransaction = {
     id: string
     expires: number
-    tx_host: string
+    tx_host?: string
 }
 
 export type RawBeginTransactionSuccessResponse = {
@@ -118,7 +118,7 @@ export class BeginTransactionResponseCodec {
         throw new Error('Not implemented')
     }
 
-    get host(): string {
+    get host(): string | undefined {
         throw new Error('Not implemented')
     }
 
@@ -140,11 +140,11 @@ class  BeginTransactionSuccessResponseCodec extends BeginTransactionResponseCode
     }
 
     get expires(): number {
-        throw this._response.transaction.expires
+        return this._response.transaction.expires
     }
 
-    get host(): string {
-        throw this._response.transaction.tx_host
+    get host(): string | undefined {
+        return this._response.transaction.tx_host
     }
 }
 
@@ -165,7 +165,7 @@ class BeginTransactionFailureResponseCodec extends BeginTransactionResponseCodec
         throw this._error
     }
 
-    get host(): string {
+    get host(): string | undefined {
         throw this._error
     }
 }
@@ -193,7 +193,7 @@ export class CommitTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return 'application/json'
+        return NEO4J_QUERY_CONTENT_TYPE
     }
 
     get accept (): string {
@@ -288,7 +288,7 @@ export class RollbackTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return 'application/json'
+        return NEO4J_QUERY_CONTENT_TYPE
     }
 
     get accept (): string {

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -248,7 +248,7 @@ class  CommitTransactionSuccessResponseCodec extends CommitTransactionResponseCo
 
     get meta(): Record<string, unknown> {
         return {
-            bookmarks: this._response.bookmarks
+            bookmark: this._response.bookmarks
         }
     }
 }

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -65,7 +65,7 @@ export class BeginTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return NEO4J_QUERY_CONTENT_TYPE
+        return 'application/json'
     }
 
     get accept (): string {
@@ -193,7 +193,7 @@ export class CommitTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return NEO4J_QUERY_CONTENT_TYPE
+        return 'application/json'
     }
 
     get accept (): string {
@@ -288,7 +288,7 @@ export class RollbackTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return NEO4J_QUERY_CONTENT_TYPE
+        return 'application/json'
     }
 
     get accept (): string {

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -23,8 +23,6 @@ export type BeginTransactionRequestCodecConfig = Pick<BeginTransactionConfig, 'b
 export type CommitTransactionRequestCodecConfig = {}
 export type RollbackTransactionRequestCodecConfig = {}
 
-
-
 export type RawTransaction = {
     id: string
     expires: number
@@ -45,7 +43,7 @@ export type RawTransactionFailuresResponse = {
     errors: RawTransactionError[]
 }
 
-export type BeginTransactionResponse = RawBeginTransactionSuccessResponse | RawTransactionFailuresResponse 
+export type RawBeginTransactionResponse = RawBeginTransactionSuccessResponse | RawTransactionFailuresResponse 
 
 export class BeginTransactionRequestCodec {
     private _body?: Record<string, unknown>
@@ -91,7 +89,7 @@ export class BeginTransactionResponseCodec {
     static of(
         config: types.InternalConfig,
         contentType: string,
-        response: BeginTransactionResponse): BeginTransactionResponseCodec {
+        response: RawBeginTransactionResponse): BeginTransactionResponseCodec {
         if (isSuccess(response)) {
             return new BeginTransactionSuccessResponseCodec(config, response)
         }
@@ -174,7 +172,7 @@ export type RawCommitTransactionSuccessResponse = {
     bookmarks: string[] | undefined
 }
 
-export type CommitTransactionResponse = RawCommitTransactionSuccessResponse | RawTransactionFailuresResponse 
+export type RawCommitTransactionResponse = RawCommitTransactionSuccessResponse | RawTransactionFailuresResponse 
 
 
 export class CommitTransactionRequestCodec {
@@ -213,7 +211,7 @@ export class CommitTransactionResponseCodec {
     static of(
         config: types.InternalConfig,
         contentType: string,
-        response: CommitTransactionResponse): CommitTransactionResponseCodec {
+        response: RawCommitTransactionResponse): CommitTransactionResponseCodec {
         if (isCommitSuccess(response)) {
             return new CommitTransactionSuccessResponseCodec(config, response)
         }
@@ -270,10 +268,10 @@ class CommitTransactionFailureResponseCodec extends CommitTransactionResponseCod
 }
 
 export type RawRollbackTransactionSuccessResponse = {
-    e: any
+    e?: any
 }
 
-export type RollbackTransactionResponse = RawRollbackTransactionSuccessResponse | RawTransactionFailuresResponse 
+export type RawRollbackTransactionResponse = RawRollbackTransactionSuccessResponse | RawTransactionFailuresResponse 
 
 
 export class RollbackTransactionRequestCodec {
@@ -312,7 +310,7 @@ export class RollbackTransactionResponseCodec {
     static of(
         config: types.InternalConfig,
         contentType: string,
-        response: RollbackTransactionResponse): RollbackTransactionResponseCodec {
+        response: RawRollbackTransactionResponse): RollbackTransactionResponseCodec {
         if (isRollbackSuccess(response)) {
             return new RollbackTransactionSuccessResponseCodec(config, response)
         }
@@ -367,7 +365,7 @@ class RollbackTransactionFailureResponseCodec extends RollbackTransactionRespons
     }
 }
 
-function isSuccess(obj: BeginTransactionResponse): obj is RawBeginTransactionSuccessResponse {
+function isSuccess(obj: RawBeginTransactionResponse): obj is RawBeginTransactionSuccessResponse {
     // @ts-expect-error
     if (obj.errors != null) {
         return false
@@ -375,7 +373,7 @@ function isSuccess(obj: BeginTransactionResponse): obj is RawBeginTransactionSuc
     return true
 }
 
-function isCommitSuccess(obj: CommitTransactionResponse): obj is RawCommitTransactionSuccessResponse {
+function isCommitSuccess(obj: RawCommitTransactionResponse): obj is RawCommitTransactionSuccessResponse {
     // @ts-expect-error
     if (obj.errors != null) {
         return false
@@ -383,7 +381,7 @@ function isCommitSuccess(obj: CommitTransactionResponse): obj is RawCommitTransa
     return true
 }
 
-function isRollbackSuccess(obj: RollbackTransactionResponse): obj is RawRollbackTransactionSuccessResponse {
+function isRollbackSuccess(obj: RawRollbackTransactionResponse): obj is RawRollbackTransactionSuccessResponse {
     // @ts-expect-error
     if (obj.errors != null) {
         return false

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -1,0 +1,429 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { error, newError, types } from "neo4j-driver-core"
+import { BeginTransactionConfig } from "neo4j-driver-core/types/connection"
+
+export type BeginTransactionRequestCodecConfig = Pick<BeginTransactionConfig, 'bookmarks' | 'txConfig' | 'mode' | 'impersonatedUser'>
+export type CommitTransactionRequestCodecConfig = {}
+export type RollbackTransactionRequestCodecConfig = {}
+
+
+// TODO: EXTRACT COMMON
+const NEO4J_QUERY_CONTENT_TYPE = 'application/vnd.neo4j.query'
+
+export type RawTransaction = {
+    id: string
+    expires: number
+    tx_host: string
+}
+
+export type RawBeginTransactionSuccessResponse = {
+    transaction: RawTransaction
+}
+
+export type RawTransactionError = {
+    code: string,
+    message: string
+    error?: string
+}
+
+export type RawTransactionFailuresResponse = {
+    errors: RawTransactionError[]
+}
+
+export type BeginTransactionResponse = RawBeginTransactionSuccessResponse | RawTransactionFailuresResponse 
+
+export class BeginTransactionRequestCodec {
+    private _body?: Record<string, unknown>
+ 
+    static of (
+        auth: types.AuthToken,
+        config?: BeginTransactionRequestCodecConfig | undefined
+    ): BeginTransactionRequestCodec {
+        return new BeginTransactionRequestCodec(auth, config)
+    }
+
+    private constructor(
+        private _auth: types.AuthToken,
+        private _config?: BeginTransactionRequestCodecConfig
+    ) {
+
+    }
+
+    get contentType (): string {
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+    }
+
+    get accept (): string {
+        // TODO: verify accept type
+        return 'application/json'
+    }
+
+    get authorization(): string {
+        // TODO: Move shared logic to common file.
+        switch (this._auth.scheme) {
+            case 'bearer':
+                return `Bearer ${btoa(this._auth.credentials)}`
+            case 'basic':
+                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
+            default:
+                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
+        }
+    }
+
+    get body (): Record<string, unknown> {
+        // TODO: MOVE COMMON LOGIC TO COMMON PLACE, MAYBE
+        if (this._body != null) {
+            return this._body
+        }
+
+        this._body = {}
+
+        if (this._config?.bookmarks != null && !this._config.bookmarks.isEmpty()) {
+            this._body.bookmarks = this._config?.bookmarks?.values()
+        }
+
+        if (this._config?.txConfig.timeout != null) {
+            this._body.maxExecutionTime = this._config?.txConfig.timeout.toInt()
+        }
+
+        if (this._config?.impersonatedUser != null) {
+            this._body.impersonatedUser = this._config?.impersonatedUser
+        }
+
+        if (this._config?.mode) {
+            this._body.accessMode = this._config.mode.toUpperCase()
+        }
+
+        return this._body
+    }
+}
+
+export class BeginTransactionResponseCodec {
+    static of(
+        config: types.InternalConfig,
+        contentType: string,
+        response: BeginTransactionResponse): BeginTransactionResponseCodec {
+        if (isSuccess(response)) {
+            return new BeginTransactionSuccessResponseCodec(config, response)
+        }
+
+        return new BeginTransactionFailureResponseCodec(response.errors?.length > 0 ?
+            newError(
+                response.errors[0].message,
+                // TODO: REMOVE THE ?? AND .ERROR WHEN SERVER IS FIXED
+                response.errors[0].code ?? response.errors[0].error
+            ) :
+            newError('Server replied an empty error response', error.PROTOCOL_ERROR))
+
+    }
+
+    get error(): Error | undefined {
+        throw new Error('Not implemented')
+    }
+
+    get id(): string {
+        throw new Error('Not implemented')
+    }
+
+    get expires(): number {
+        throw new Error('Not implemented')
+    }
+
+    get host(): string {
+        throw new Error('Not implemented')
+    }
+
+}
+
+class  BeginTransactionSuccessResponseCodec extends BeginTransactionResponseCodec {
+    constructor(
+        private readonly _config: types.InternalConfig, 
+        private readonly _response: RawBeginTransactionSuccessResponse) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return undefined;
+    }
+
+    get id(): string {
+        return this._response.transaction.id
+    }
+
+    get expires(): number {
+        throw this._response.transaction.expires
+    }
+
+    get host(): string {
+        throw this._response.transaction.tx_host
+    }
+}
+
+class BeginTransactionFailureResponseCodec extends BeginTransactionResponseCodec {
+    constructor(private readonly _error: Error) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return this._error
+    }
+
+    get id(): string {
+        throw this._error
+    }
+
+    get expires(): number {
+        throw this._error
+    }
+
+    get host(): string {
+        throw this._error
+    }
+}
+
+export type RawCommitTransactionSuccessResponse = {
+    bookmarks: string[] | undefined
+}
+
+export type CommitTransactionResponse = RawCommitTransactionSuccessResponse | RawTransactionFailuresResponse 
+
+
+export class CommitTransactionRequestCodec {
+    static of (
+        auth: types.AuthToken,
+        config?: CommitTransactionRequestCodecConfig | undefined
+    ): CommitTransactionRequestCodec {
+        return new CommitTransactionRequestCodec(auth, config)
+    }
+
+    private constructor(
+        private _auth: types.AuthToken,
+        private _config?: CommitTransactionRequestCodecConfig
+    ) {
+
+    }
+
+    get contentType (): string {
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+    }
+
+    get accept (): string {
+        // TODO: verify accept type
+        return 'application/json'
+    }
+
+    get authorization(): string {
+        // TODO: Move shared logic to common file.
+        switch (this._auth.scheme) {
+            case 'bearer':
+                return `Bearer ${btoa(this._auth.credentials)}`
+            case 'basic':
+                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
+            default:
+                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
+        }
+    }
+}
+
+export class CommitTransactionResponseCodec {
+    static of(
+        config: types.InternalConfig,
+        contentType: string,
+        response: CommitTransactionResponse): CommitTransactionResponseCodec {
+        if (isCommitSuccess(response)) {
+            return new CommitTransactionSuccessResponseCodec(config, response)
+        }
+
+        return new CommitTransactionFailureResponseCodec(response.errors?.length > 0 ?
+            newError(
+                response.errors[0].message,
+                // TODO: REMOVE THE ?? AND .ERROR WHEN SERVER IS FIXED
+                response.errors[0].code ?? response.errors[0].error
+            ) :
+            newError('Server replied an empty error response', error.PROTOCOL_ERROR))
+
+    }
+
+    get error(): Error | undefined {
+        throw new Error('Not implemented')
+    }
+
+    get meta(): Record<string, unknown> {
+        throw new Error('Not implemented')
+    }
+}
+
+class  CommitTransactionSuccessResponseCodec extends CommitTransactionResponseCodec {
+    constructor(
+        private readonly _config: types.InternalConfig, 
+        private readonly _response: RawCommitTransactionSuccessResponse) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return undefined;
+    }
+
+    get meta(): Record<string, unknown> {
+        return {
+            bookmarks: this._response.bookmarks
+        }
+    }
+}
+
+class CommitTransactionFailureResponseCodec extends CommitTransactionResponseCodec {
+    constructor(private readonly _error: Error) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return this._error
+    }
+
+    get meta(): Record<string, unknown> {
+        throw this._error
+    }
+}
+
+export type RawRollbackTransactionSuccessResponse = {
+    e: any
+}
+
+export type RollbackTransactionResponse = RawRollbackTransactionSuccessResponse | RawTransactionFailuresResponse 
+
+
+export class RollbackTransactionRequestCodec {
+    static of (
+        auth: types.AuthToken,
+        config?: RollbackTransactionRequestCodecConfig | undefined
+    ): RollbackTransactionRequestCodec {
+        return new RollbackTransactionRequestCodec(auth, config)
+    }
+
+    private constructor(
+        private _auth: types.AuthToken,
+        private _config?: RollbackTransactionRequestCodecConfig
+    ) {
+
+    }
+
+    get contentType (): string {
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+    }
+
+    get accept (): string {
+        // TODO: verify accept type
+        return 'application/json'
+    }
+
+    get authorization(): string {
+        // TODO: Move shared logic to common file.
+        switch (this._auth.scheme) {
+            case 'bearer':
+                return `Bearer ${btoa(this._auth.credentials)}`
+            case 'basic':
+                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
+            default:
+                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
+        }
+    }
+}
+
+export class RollbackTransactionResponseCodec {
+    static of(
+        config: types.InternalConfig,
+        contentType: string,
+        response: RollbackTransactionResponse): RollbackTransactionResponseCodec {
+        if (isRollbackSuccess(response)) {
+            return new RollbackTransactionSuccessResponseCodec(config, response)
+        }
+
+        return new RollbackTransactionFailureResponseCodec(response.errors?.length > 0 ?
+            newError(
+                response.errors[0].message,
+                // TODO: REMOVE THE ?? AND .ERROR WHEN SERVER IS FIXED
+                response.errors[0].code ?? response.errors[0].error
+            ) :
+            newError('Server replied an empty error response', error.PROTOCOL_ERROR))
+
+    }
+
+    get error(): Error | undefined {
+        throw new Error('Not implemented')
+    }
+
+    get meta(): Record<string, unknown> {
+        throw new Error('Not implemented')
+    }
+}
+
+class  RollbackTransactionSuccessResponseCodec extends RollbackTransactionResponseCodec {
+    constructor(
+        private readonly _config: types.InternalConfig, 
+        private readonly _response: RawRollbackTransactionSuccessResponse) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return undefined;
+    }
+
+    get meta(): Record<string, unknown> {
+        return {
+        }
+    }
+}
+
+class RollbackTransactionFailureResponseCodec extends RollbackTransactionResponseCodec {
+    constructor(private readonly _error: Error) {
+        super()
+    }
+
+    get error(): Error | undefined {
+        return this._error
+    }
+
+    get meta(): Record<string, unknown> {
+        throw this._error
+    }
+}
+
+function isSuccess(obj: BeginTransactionResponse): obj is RawBeginTransactionSuccessResponse {
+    // @ts-expect-error
+    if (obj.errors != null) {
+        return false
+    }
+    return true
+}
+
+function isCommitSuccess(obj: CommitTransactionResponse): obj is RawCommitTransactionSuccessResponse {
+    // @ts-expect-error
+    if (obj.errors != null) {
+        return false
+    }
+    return true
+}
+
+function isRollbackSuccess(obj: RollbackTransactionResponse): obj is RawRollbackTransactionSuccessResponse {
+    // @ts-expect-error
+    if (obj.errors != null) {
+        return false
+    }
+    return true
+}

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -200,6 +200,10 @@ export class CommitTransactionRequestCodec {
         return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
     }
 
+    get body () : Record<string, unknown> {
+        return {}
+    }
+
     get authorization(): string {
         return encodeAuthToken(this._auth)
     }
@@ -285,6 +289,10 @@ export class RollbackTransactionRequestCodec {
         private _config?: RollbackTransactionRequestCodecConfig
     ) {
 
+    }
+
+    get body () : Record<string, unknown> {
+        return {}
     }
 
     get contentType (): string {

--- a/src/http-connection/transaction.codec.ts
+++ b/src/http-connection/transaction.codec.ts
@@ -17,14 +17,13 @@
 
 import { error, newError, types } from "neo4j-driver-core"
 import { BeginTransactionConfig } from "neo4j-driver-core/types/connection"
+import { NEO4J_QUERY_CONTENT_TYPE, encodeAuthToken, encodeTransactionBody } from "./codec"
 
 export type BeginTransactionRequestCodecConfig = Pick<BeginTransactionConfig, 'bookmarks' | 'txConfig' | 'mode' | 'impersonatedUser'>
 export type CommitTransactionRequestCodecConfig = {}
 export type RollbackTransactionRequestCodecConfig = {}
 
 
-// TODO: EXTRACT COMMON
-const NEO4J_QUERY_CONTENT_TYPE = 'application/vnd.neo4j.query'
 
 export type RawTransaction = {
     id: string
@@ -66,49 +65,23 @@ export class BeginTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+        return NEO4J_QUERY_CONTENT_TYPE
     }
 
     get accept (): string {
-        // TODO: verify accept type
-        return 'application/json'
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
     }
 
     get authorization(): string {
-        // TODO: Move shared logic to common file.
-        switch (this._auth.scheme) {
-            case 'bearer':
-                return `Bearer ${btoa(this._auth.credentials)}`
-            case 'basic':
-                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
-            default:
-                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
-        }
+        return encodeAuthToken(this._auth)
     }
 
     get body (): Record<string, unknown> {
-        // TODO: MOVE COMMON LOGIC TO COMMON PLACE, MAYBE
         if (this._body != null) {
             return this._body
         }
 
-        this._body = {}
-
-        if (this._config?.bookmarks != null && !this._config.bookmarks.isEmpty()) {
-            this._body.bookmarks = this._config?.bookmarks?.values()
-        }
-
-        if (this._config?.txConfig.timeout != null) {
-            this._body.maxExecutionTime = this._config?.txConfig.timeout.toInt()
-        }
-
-        if (this._config?.impersonatedUser != null) {
-            this._body.impersonatedUser = this._config?.impersonatedUser
-        }
-
-        if (this._config?.mode) {
-            this._body.accessMode = this._config.mode.toUpperCase()
-        }
+        this._body = encodeTransactionBody(this._config)
 
         return this._body
     }
@@ -220,24 +193,15 @@ export class CommitTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
-    }
-
-    get accept (): string {
-        // TODO: verify accept type
         return 'application/json'
     }
 
+    get accept (): string {
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+    }
+
     get authorization(): string {
-        // TODO: Move shared logic to common file.
-        switch (this._auth.scheme) {
-            case 'bearer':
-                return `Bearer ${btoa(this._auth.credentials)}`
-            case 'basic':
-                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
-            default:
-                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
-        }
+        return encodeAuthToken(this._auth)
     }
 }
 
@@ -324,24 +288,15 @@ export class RollbackTransactionRequestCodec {
     }
 
     get contentType (): string {
-        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
-    }
-
-    get accept (): string {
-        // TODO: verify accept type
         return 'application/json'
     }
 
+    get accept (): string {
+        return `${NEO4J_QUERY_CONTENT_TYPE}, application/json`
+    }
+
     get authorization(): string {
-        // TODO: Move shared logic to common file.
-        switch (this._auth.scheme) {
-            case 'bearer':
-                return `Bearer ${btoa(this._auth.credentials)}`
-            case 'basic':
-                return `Basic ${btoa(`${this._auth.principal}:${this._auth.credentials}`)}`
-            default:
-                throw new Error(`Authorization scheme "${this._auth.scheme}" is not supported.`)
-        }
+        return encodeAuthToken(this._auth)
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,10 @@ import {
   types as coreTypes,
   UnboundRelationship,
   driver as coreDriver,
-  
+  Transaction,
+  TransactionConfig,
+  TransactionPromise,
+  ManagedTransaction
 } from 'neo4j-driver-core'
 
 import { logging } from './logging'
@@ -311,6 +314,9 @@ const forExport = {
   Result,
   Record,
   ResultSummary,
+  Transaction,
+  TransactionPromise,
+  ManagedTransaction,
   Node,
   Relationship,
   UnboundRelationship,
@@ -382,6 +388,9 @@ export {
   Notification,
   ServerInfo,
   Session,
+  Transaction,
+  TransactionPromise,
+  ManagedTransaction,
   Point,
   Duration,
   LocalTime,
@@ -416,6 +425,7 @@ export type {
   QueryConfig,
   RecordShape,
   ResultTransformer,
+  TransactionConfig,
   NotificationCategory,
   NotificationSeverityLevel,
   Logger,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,11 +26,11 @@ type VerifyAuthentication = {
 }
 
 type HttpUrl = `http://${string}` | `https://${string}`
-type WrapperSession = Pick<Session, 'run' | 'beginTransaction' | 'lastBookmarks' | 'close' > & Disposable 
+type WrapperSession = Pick<Session, 'run' | 'beginTransaction' | 'executeRead' | 'executeWrite' | 'lastBookmarks' | 'close' > & Disposable 
 type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode' | 'auth'> & {
   database: string
 }
-type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb'| 'supportsSessionAuth' | 'supportsUserImpersonation'> & Disposable & VerifyConnectivity & VerifyAuthentication & {
+type Wrapper = Pick<Driver, 'close' | 'executeQuery' | 'executeQueryBookmarkManager' | 'supportsMultiDb'| 'supportsSessionAuth' | 'supportsUserImpersonation'> & Disposable & VerifyConnectivity & VerifyAuthentication & {
   session(config: WrapperSessionConfig): WrapperSession
 } 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ type VerifyAuthentication = {
 }
 
 type HttpUrl = `http://${string}` | `https://${string}`
-type WrapperSession = Pick<Session, 'run' | 'lastBookmarks' | 'close' > & Disposable 
+type WrapperSession = Pick<Session, 'run' | 'beginTransaction' | 'lastBookmarks' | 'close' > & Disposable 
 type WrapperSessionConfig = Pick<SessionConfig, 'bookmarks' | 'impersonatedUser' | 'bookmarkManager' | 'defaultAccessMode' | 'auth'> & {
   database: string
 }
@@ -34,7 +34,9 @@ type Wrapper = Pick<Driver, 'close' | 'supportsMultiDb'| 'supportsSessionAuth' |
   session(config: WrapperSessionConfig): WrapperSession
 } 
 
-type WrapperConfig = Pick<Config, 'encrypted' | 'useBigInt' | 'disableLosslessIntegers' | 'maxConnectionPoolSize' | 'connectionAcquisitionTimeout'>
+type WrapperConfig = Pick<Config, 'encrypted' | 'useBigInt' | 'disableLosslessIntegers' | 'maxConnectionPoolSize' | 'connectionAcquisitionTimeout'> & {
+  httpSessionAffinityHeader?: string
+}
 
 export type {
   HttpUrl,

--- a/src/wrapper-session.impl.ts
+++ b/src/wrapper-session.impl.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RecordShape, TransactionConfig, Result, Session, TransactionPromise } from "neo4j-driver-core";
+import { RecordShape, TransactionConfig, Result, Session, TransactionPromise, ManagedTransaction } from "neo4j-driver-core";
 import { Query } from "neo4j-driver-core/types/types";
 import { WrapperSession } from "./types";
 
@@ -34,6 +34,14 @@ export default class WrapperSessionImpl implements WrapperSession {
 
     beginTransaction(transactionConfig?: TransactionConfig | undefined): TransactionPromise {
         return this.session.beginTransaction(transactionConfig)
+    }
+
+    executeRead<T>(transactionWork: (tx: ManagedTransaction) => T | Promise<T>, transactionConfig?: TransactionConfig | undefined): Promise<T> {
+        return this.session.executeRead(transactionWork, transactionConfig)
+    }
+
+    executeWrite<T>(transactionWork: (tx: ManagedTransaction) => T | Promise<T>, transactionConfig?: TransactionConfig | undefined): Promise<T> {
+        return this.session.executeWrite(transactionWork, transactionConfig)
     }
     
     lastBookmarks(): string[] {

--- a/src/wrapper-session.impl.ts
+++ b/src/wrapper-session.impl.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RecordShape, TransactionConfig, Result, Session } from "neo4j-driver-core";
+import { RecordShape, TransactionConfig, Result, Session, TransactionPromise } from "neo4j-driver-core";
 import { Query } from "neo4j-driver-core/types/types";
 import { WrapperSession } from "./types";
 
@@ -30,6 +30,10 @@ export default class WrapperSessionImpl implements WrapperSession {
 
     run<R extends RecordShape = RecordShape>(query: Query, parameters?: any, transactionConfig?: TransactionConfig | undefined): Result<R> {
         return this.session.run(query, parameters, transactionConfig)
+    }
+
+    beginTransaction(transactionConfig?: TransactionConfig | undefined): TransactionPromise {
+        return this.session.beginTransaction(transactionConfig)
     }
     
     lastBookmarks(): string[] {

--- a/src/wrapper.impl.ts
+++ b/src/wrapper.impl.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Driver, ServerInfo, types } from "neo4j-driver-core";
+import { BookmarkManager, Driver, EagerResult, QueryConfig, RecordShape, ServerInfo, types } from "neo4j-driver-core";
 import { Wrapper, WrapperSession, WrapperSessionConfig } from "./types";
 import WrapperSessionImpl from "./wrapper-session.impl";
 
@@ -25,6 +25,15 @@ export class WrapperImpl implements Wrapper {
 
     close(): Promise<void> {
         return this.driver.close()
+    }
+
+    executeQuery<T = EagerResult<RecordShape>>(query: types.Query, parameters?: any, config?: QueryConfig<T> | undefined): Promise<T> {
+        validateDatabase(config)
+        return this.driver.executeQuery(query, parameters, config)
+    }
+
+    get executeQueryBookmarkManager(): BookmarkManager {
+        return this.driver.executeQueryBookmarkManager
     }
     
     verifyConnectivity(config: { database: string }): Promise<ServerInfo> {
@@ -62,8 +71,8 @@ export class WrapperImpl implements Wrapper {
     }
 }
 
-function validateDatabase(config: { database: string }): void {
-    if (config.database == null || config.database === '') {
-        throw new TypeError(`database must be a non-empty string, but got ${config.database}`)
+function validateDatabase(config: { database?: string } | undefined): void {
+    if (config == null || config.database == null || config.database === '') {
+        throw new TypeError(`database must be a non-empty string, but got ${config?.database}`)
     }
 }

--- a/test/integration/config/index.ts
+++ b/test/integration/config/index.ts
@@ -16,6 +16,7 @@
  */
 import Neo4jContainer from './neo4j.container'
 import WireMockContainer from './wiremock.container'
+import neo4j from '../../../src'
 
 const env = process.env
 
@@ -27,6 +28,7 @@ const version = env.TEST_NEO4J_VERSION ?? '5.23'
 const httpPort = env.TEST_NEO4J_HTTP_PORT ?? 7474
 const boltPort = env.TEST_NEO4J_BOLT_PORT ?? 7687
 const edition = env.TEST_NEO4J_EDITION ?? 'enterprise'
+const logLevel = env.TEST_DRIVER_LOG_LEVEL 
 const printContainerLogs = env.TEST_CONTAINERS_LOGS !== undefined
         ? env.TEST_CONTAINERS_LOGS.toUpperCase() === 'TRUE'
         : false
@@ -85,5 +87,11 @@ export default {
   },
   async deleteWireMockStub (stubId?: string): Promise<void> {
     return await wireMockContainer.deleteStub(stubId)
+  },
+  get loggingConfig () {
+    if (logLevel != null) {
+      return neo4j.logging.console(logLevel as any)
+    }
+    return undefined
   }
 }

--- a/test/integration/config/index.ts
+++ b/test/integration/config/index.ts
@@ -24,6 +24,7 @@ const username = env.TEST_NEO4J_USER ?? 'neo4j'
 const password = env.TEST_NEO4J_PASS ?? 'password'
 const hostname = env.TEST_NEO4J_HOST ?? 'localhost'
 const scheme = env.TEST_NEO4J_SCHEME ?? 'bolt'
+const httpScheme = env.TEST_NEO4J_HTTP_SCHEME ?? 'http'
 const version = env.TEST_NEO4J_VERSION ?? '5.23'
 const httpPort = env.TEST_NEO4J_HTTP_PORT ?? 7474
 const boltPort = env.TEST_NEO4J_BOLT_PORT ?? 7687
@@ -47,6 +48,7 @@ export default {
   password,
   hostname,
   scheme,
+  httpScheme,
   cluster,
   database,
   get testNonClusterSafe () {

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 import config from './config'
-import neo4j, { Date, DateTime, Duration, LocalDateTime, LocalTime, Neo4jError, Plan, Point, ProfiledPlan, Time, Wrapper, WrapperSession, WrapperSessionConfig, int } from '../../src'
+import neo4j, { Date, DateTime, Duration, LocalDateTime, LocalTime, Neo4jError, Plan, Point, ProfiledPlan, Result, Time, TransactionConfig, Wrapper, WrapperSession, WrapperSessionConfig, int } from '../../src'
 import { when, withSession as _withSession } from './test.utils'
 
 const NESTED_OBJECT = { 
@@ -66,7 +66,7 @@ const OBJECT_OF_LISTS = {
   b: [1, 2]
 }
 
-when(config.version >= 5.23, () => describe('minimum requirement', () => {
+when(config.version >= 5.23, () => describe.each(runners())('minimum requirement %s', (_, runner) => {
   let wrapper: Wrapper
 
   beforeAll(async () => {
@@ -80,7 +80,10 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
   beforeEach(() => {
     wrapper = neo4j.wrapper(
       `http://${config.hostname}:${config.httpPort}`,
-      neo4j.auth.basic(config.username, config.password)
+      neo4j.auth.basic(config.username, config.password),
+      { 
+        logging: config.loggingConfig
+      }
     )
   })
 
@@ -170,7 +173,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     ['object of lists', v(OBJECT_OF_LISTS)]
   ])('should be able to echo "%s" (%s)', async (_, [input, expectedOutput]) => {
     for await (const session of withSession({ database: config.database })) {
-      const { records: [first] } = await session.run('RETURN $input as output',  { input })
+      const { records: [first] } = await runner(session, 'RETURN $input as output',  { input })
       expect(first.get('output')).toEqual(expectedOutput) 
     } 
   })
@@ -179,7 +182,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     for await (const session of withSession({ database: config.database })) {
       const dt = new DateTime(int(1999), int(6), int(12), int(1), int(2), int(20), int(234), undefined, 'Europe/Berlin')
 
-      await expect(session.run(`RETURN $dt`, { dt })).rejects.toEqual(new Error(
+      await expect(runner(session, `RETURN $dt`, { dt })).rejects.toEqual(new Error(
         'DateTime objects without "timeZoneOffsetSeconds" property ' +
                 'are prone to bugs related to ambiguous times. For instance, ' +
                 '2022-10-30T2:30:00[Europe/Berlin] could be GMT+1 or GMT+2.'
@@ -203,14 +206,14 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     ['Datetime "2020-01-01', 'datetime("2020-01-01")', new DateTime(int(2020), int(1), int(1), int(0), int(0), int(0), int(0), int(0))] 
   ])('should be able to echo "%s" (%s)', async (_, statement, expectedOutput) => {
     for await (const session of withSession({ database: config.database })) {
-      const { records: [first] } = await session.run(`RETURN ${statement} as output`)
+      const { records: [first] } = await runner(session, `RETURN ${statement} as output`)
       expect(first.get('output')).toEqual(expectedOutput) 
     }
   })
 
   it('should be able to return ResultSummary.counters', async () => {
     for await (const session of withSession({ database: config.database })) {
-      const { summary: { counters} } = await session.run(
+      const { summary: { counters} } = await runner(session, 
         'CREATE (n: Person { name: "This person"})-[:WORKS_WITH]->(:Person { name: "Other person" }) ' +
         'RETURN n')
 
@@ -235,7 +238,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
   it('should be able to return ResultSummary.plan', async () => {
     for await (const session of withSession({ database: config.database })) {
-      const { summary} = await session.run('PROFILE RETURN 1')
+      const { summary} = await runner(session, 'PROFILE RETURN 1')
 
       expect(summary.plan).not.toBe(false)
       
@@ -281,7 +284,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
   it('should be able to return ResultSummary.profile',async () => {
     for await (const session of withSession({ database: config.database })) {
-      const { summary} = await session.run('PROFILE RETURN 1')
+      const { summary} = await runner(session, 'PROFILE RETURN 1')
 
       expect(summary.profile).not.toBe(false)
       
@@ -341,13 +344,13 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     for await (const session of withSession({ database: config.database })) {
       expect(session.lastBookmarks()).toEqual([])
 
-      await session.run('RETURN 1')
+      await runner(session, 'RETURN 1')
 
       expect(session.lastBookmarks()).toHaveLength(1)
       expect(typeof session.lastBookmarks()[0]).toBe('string')
       const [previousBookmark] = session.lastBookmarks()
 
-      await session.run('CREATE (n:Person { name: $name }) RETURN n', { name: 'My Mom'})
+      await runner(session, 'CREATE (n:Person { name: $name }) RETURN n', { name: 'My Mom'})
 
       expect(session.lastBookmarks()).toHaveLength(1)
       expect(typeof session.lastBookmarks()[0]).toBe('string')
@@ -357,7 +360,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
   it('should be able to return notifications', async () => {
     for await (const session of withSession({ database: config.database })) {
-      const { summary} = await session.run('MATCH (a: NonExistentLabel) USING INDEX a:NonExistentLabel(id) WHERE a.id = 1 RETURN a')
+      const { summary} = await runner(session, 'MATCH (a: NonExistentLabel) USING INDEX a:NonExistentLabel(id) WHERE a.id = 1 RETURN a')
 
       expect(summary.notifications.length).toBe(3)
 
@@ -391,7 +394,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
   it('should be able to set access mode', async () => {
     for await (const session of withSession({ database: config.database, defaultAccessMode: 'READ' })) {
-      const error = await session.run('CREATE (:Person {name: $name })', { name: 'Gregory Irons'}).summary().catch(e => e)
+      const error = await runner(session, 'CREATE (:Person {name: $name })', { name: 'Gregory Irons'}).catch(e => e)
       
       expect(error).toBeInstanceOf(Neo4jError)
       expect(error.code).toEqual('Neo.ClientError.Statement.AccessMode')
@@ -402,7 +405,7 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
 
   it('should be able to set tx timeout', async () => {
     for await (const session of withSession({ database: config.database })) {
-      await expect(session.run('CREATE (:Person {name: $name })', { name: 'Gregory Irons'}, { timeout: 123 }).summary()).resolves.not.toBeNull()
+      await expect(runner(session, 'CREATE (:Person {name: $name })', { name: 'Gregory Irons'}, { timeout: 123 })).resolves.not.toBeNull()
     }
   })
 
@@ -416,19 +419,22 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
             password = config.password
           }
         }
-      })
+      }),
+      {
+        logging: config.loggingConfig
+      }
     )
 
     for await (const session of withSession({ database: config.database })) {
-      const error = await session.run('CREATE (:Person {name: $name })', { name: 'Gregory Irons'}).summary().catch(e => e)
+      const error = await runner(session, 'CREATE (:Person {name: $name })', { name: 'Gregory Irons'}).catch(e => e)
       
       expect(error).toBeInstanceOf(Neo4jError)
-      expect(error.retriable).toEqual(true)
       expect(error.code).toEqual('Neo.ClientError.Security.Unauthorized')
+      expect(error.retriable).toEqual(true)
       expect(typeof error.message).toEqual('string')
       expect(error.message.trim()).not.toEqual('')
 
-      await session.run('CREATE (:Person {name: $name })', { name: 'Gregory Irons'}).summary()
+      await runner(session, 'CREATE (:Person {name: $name })', { name: 'Gregory Irons'})
     }
   })
 
@@ -444,3 +450,30 @@ when(config.version >= 5.23, () => describe('minimum requirement', () => {
     return [value, mapper(value)]
   }
 }))
+
+function runners (): [string, Runner][] {
+  let runners: [string, Runner][] = [
+    ['session.run', async (session: WrapperSession, text: string, parameters?: any, config?: TransactionConfig): Promise<Result> => session.run(text, parameters, config)]
+  ]
+
+  if (config.version >= 5.26) {
+    runners = [
+      ...runners,
+      ['session.beginTransaction', async (session: WrapperSession, text: string, parameters?: any, config?: TransactionConfig): Promise<Result> => {
+        const tx = session.beginTransaction(config)
+        try {
+          const result =  await tx.run(text, parameters)
+          await tx.commit()
+          return result
+        } finally {
+          await tx.close()
+        }
+      }]
+    ]
+  }
+
+  return runners
+}
+
+type Runner = (session: WrapperSession, text: string, parameters?: any, config?: TransactionConfig) => Promise<Result>
+  

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -79,7 +79,7 @@ when(config.version >= 5.23, () => describe.each(runners())('minimum requirement
 
   beforeEach(() => {
     wrapper = neo4j.wrapper(
-      `http://${config.hostname}:${config.httpPort}`,
+      `${config.httpScheme}://${config.hostname}:${config.httpPort}`,
       neo4j.auth.basic(config.username, config.password),
       { 
         logging: config.loggingConfig

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -35,7 +35,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
       `http://${config.hostname}:${config.httpPort}`,
       neo4j.auth.basic(config.username, config.password),
       { 
-        logging: neo4j.logging.console('debug')
+        logging: config.loggingConfig
       }
     )
   })

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -58,10 +58,8 @@ when(config.version >= 5.26, () => describe('transactions', () => {
         const tx = await session.beginTransaction()
         try  {
           for (let i = 0; i < queries; i++) {
-            //  TODO FIXME, SEND ME AS A PARAM
-            await expect(tx.run(`RETURN ${i} AS a`)).resolves.toBeDefined()
+            await expect(tx.run('RETURN $i AS a', { i })).resolves.toBeDefined()
           }
-
           await expect(tx.commit()).resolves.toBe(undefined)
         } finally {
           await tx.close()
@@ -79,8 +77,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
         const tx = await session.beginTransaction()
         try  {
           for (let i = 0; i < queries; i++) {
-            //  TODO FIXME, SEND ME AS A PARAM
-            await expect(tx.run(`CREATE (n:Person{a:${i}}) RETURN n.a AS a`)).resolves.toBeDefined()
+            await expect(tx.run('CREATE (n:Person{a:$i}) RETURN n.a AS a', { i })).resolves.toBeDefined()
           }
 
           await expect(tx.commit()).resolves.toBe(undefined)
@@ -101,8 +98,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
       for await (const session of withSession(wrapper, { database: config.database })) {
         await expect(session.executeRead(async tx => {
           for (let i = 0; i < queries; i++) {
-            //  TODO FIXME, SEND ME AS A PARAM
-            await expect(tx.run(`RETURN ${i} AS a`)).resolves.toBeDefined()
+            await expect(tx.run('RETURN $i AS a', { i })).resolves.toBeDefined()
           }
         })).resolves.toBe(undefined)
       }
@@ -117,8 +113,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
       for await (const session of withSession(wrapper, { database: config.database, })) {
         await expect(session.executeWrite(async tx => {
           for (let i = 0; i < queries; i++) {
-            //  TODO FIXME, SEND ME AS A PARAM
-            await expect(tx.run(`CREATE (n:Person{a:${i}}) RETURN n.a AS a`)).resolves.toBeDefined()
+            await expect(tx.run('CREATE (n:Person{a:$i}) RETURN n.a AS a', { i })).resolves.toBeDefined()
           }
         })).resolves.toBe(undefined)
       }
@@ -126,7 +121,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
 
     it('should be able to run a read query using executeQuery', async () => {
       const i = 34
-      await expect(wrapper.executeQuery(`RETURN ${i} AS a`, undefined, {
+      await expect(wrapper.executeQuery('RETURN $i AS a', { i }, {
         database: config.database,
         routing: 'READ'
       })).resolves.toBeDefined()
@@ -134,7 +129,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
 
     it('should be able to run a write query using executeQuery', async () => {
       const i = 34
-      await expect(wrapper.executeQuery(`CREATE (n:Person{a:${i}}) RETURN n.a AS a`, undefined, {
+      await expect(wrapper.executeQuery('CREATE (n:Person{a:$i}) RETURN n.a AS a', { i }, {
         database: config.database,
         routing: 'WRITE'
       })).resolves.toBeDefined()

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -19,7 +19,7 @@ import config from './config'
 import { when, withSession } from './test.utils'
 import neo4j, { Wrapper } from '../../src'
 
-when(config.version >= 5.26, () => describe('transactions', () => {
+when(config.version >= 5.25, () => describe('transactions', () => {
   let wrapper: Wrapper
 
   beforeAll(async () => {

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -19,7 +19,7 @@ import config from './config'
 import { when, withSession } from './test.utils'
 import neo4j, { Wrapper } from '../../src'
 
-when(config.version >= 5.25, () => describe('transactions', () => {
+when(config.version >= 5.26, () => describe('transactions', () => {
   let wrapper: Wrapper
 
   beforeAll(async () => {

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -1,0 +1,68 @@
+
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import config from './config'
+import { when, withSession } from './test.utils'
+import neo4j, { Wrapper } from '../../src'
+
+when(config.version >= 5.26, () => describe('transactions', () => {
+  let wrapper: Wrapper
+
+  beforeAll(async () => {
+    await config.startNeo4j()
+  }, 120_000) // long timeout since it may need to download docker image
+
+  afterAll(async () => {
+    await config.stopNeo4j()
+  }, 20000)
+
+  beforeEach(() => {
+    wrapper = neo4j.wrapper(
+      `http://${config.hostname}:${config.httpPort}`,
+      neo4j.auth.basic(config.username, config.password)
+    )
+  })
+
+  afterEach(async () => {
+    for await (const session of withSession(wrapper, { database: config.database })) {
+      await session.run('MATCH (n) DETACH DELETE n')
+    }
+    await wrapper?.close()
+  })
+
+  describe('unmanaged', () => {
+    it.each([
+      [0],
+      [1],
+      [2],
+      [5]
+    ])('should be able run %s queries and commit a read tx', async (queries) => {
+      for await (const session of withSession(wrapper, { database: config.database, defaultAccessMode: 'READ' })) {
+        const tx = await session.beginTransaction()
+        try  {
+          for (let i = 0; i < queries; i++) {
+            await expect(tx.run('RETURN $a AS a', { a: i })).resolves.toBeDefined()
+          }
+
+          await expect(tx.commit()).resolves.toBeDefined()
+        } finally {
+          await tx.close()
+        }
+      }
+    })
+  })
+}))

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -32,7 +32,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
 
   beforeEach(() => {
     wrapper = neo4j.wrapper(
-      `http://${config.hostname}:${config.httpPort}`,
+      `${config.httpScheme}://${config.hostname}:${config.httpPort}`,
       neo4j.auth.basic(config.username, config.password),
       { 
         logging: config.loggingConfig

--- a/test/unit/http-connection/lang/pipe.test.ts
+++ b/test/unit/http-connection/lang/pipe.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Pipe from "../../../../src/http-connection/lang/pipe"
+
+describe('Pipe', () => {
+    describe('when newly created', () => {
+        it.each(successWorkFixture())('should execute work %s', async (_, func) => {
+            const pipe = new Pipe()
+            const work = jest.fn(func)
+
+            await expect(pipe.attach(work)).resolves.toBe(undefined)
+
+            expect(work).toHaveBeenCalled()
+        })
+
+        it.each(failedWorkFixture())('should report failure on the work %s', async (_, workFactory) => {
+            const expectedError = new Error('My fun error')
+            const pipe = new Pipe()
+            const work = jest.fn(workFactory(expectedError))
+
+            await expect(pipe.attach(work)).rejects.toBe(expectedError)
+        })
+    })
+
+    describe.each(successWorkFixture())('when success execute previous work %s', (_, previousWorkFunc) => {
+        it.each(successWorkFixture())('should execute work %s', async (_, func) => {
+            const pipe = new Pipe()
+            const work = jest.fn(func)
+            await expect(pipe.attach(previousWorkFunc)).resolves.toBe(undefined)
+
+            await expect(pipe.attach(work)).resolves.toBe(undefined)
+
+            expect(work).toHaveBeenCalled()
+        })
+
+        it.each(failedWorkFixture())('should report failure on the work %s', async (_, workFactory) => {
+            const expectedError = new Error('My fun error')
+            const pipe = new Pipe()
+            const work = jest.fn(workFactory(expectedError))
+            await expect(pipe.attach(previousWorkFunc)).resolves.toBe(undefined)
+
+            await expect(pipe.attach(work)).rejects.toBe(expectedError)
+        })
+    })
+
+    describe.each(failedWorkFixture())('when failed execute previous work %s', (_, previousWorkFunc) => {
+        it.each(successWorkFixture())('should not execute work %s and fail', async (_, func) => {
+            const expectedFailure = new Error('I am the expected failure')
+            const pipe = new Pipe()
+            const work = jest.fn(func)
+            await expect(pipe.attach(previousWorkFunc(expectedFailure))).rejects.toBe(expectedFailure)
+
+            await expect(pipe.attach(work)).rejects.toBe(expectedFailure)
+
+            expect(work).not.toHaveBeenCalled()
+        })
+
+        it.each(failedWorkFixture())('should report failure on the work %s', async (_, workFactory) => {
+            const expectedFailure = new Error('I am the expected failure')
+            const notExpected = new Error('I am an error that should not happen')
+            const pipe = new Pipe()
+            const work = jest.fn(workFactory(notExpected))
+            await expect(pipe.attach(previousWorkFunc(expectedFailure))).rejects.toBe(expectedFailure)
+
+            await expect(pipe.attach(work)).rejects.toBe(expectedFailure)
+
+            expect(work).not.toHaveBeenCalled()
+        })
+
+        describe('but chain is recovery', () => {
+            it.each(successWorkFixture())('should execute work %s', async (_, func) => {
+                const failure = new Error('I am a failure, but dont bother')
+                const pipe = new Pipe()
+                const work = jest.fn(func)
+                const failedWork = pipe.attach(previousWorkFunc(failure))
+
+                pipe.recover()
+                
+                await expect(pipe.attach(work)).resolves.toBe(undefined)
+
+                await expect(failedWork).rejects.toBe(failure)
+                expect(work).toHaveBeenCalled()
+            })
+
+            it.each(failedWorkFixture())('should report failure on the work %s', async (_, workFactory) => {
+                const failure = new Error('I am a failure, but dont bother')
+                const expectedError = new Error('My fun error')
+                const pipe = new Pipe()
+                const work = jest.fn(workFactory(expectedError))
+                const failedWork = pipe.attach(previousWorkFunc(failure))
+
+                pipe.recover()
+    
+                await expect(pipe.attach(work)).rejects.toBe(expectedError)
+
+                await expect(failedWork).rejects.toBe(failure)
+            })
+        })
+    })
+
+    function successWorkFixture (): [string, () => Promise<void> | void][] {
+        return [
+            ['async', async () => {}],
+            ['sync', () => {}]
+        ]
+    }
+
+    function failedWorkFixture (): [string, (error: Error) => () => Promise<void> | void][] {
+        return [
+            ['async', (error) => async () => { throw error }],
+            ['sync', (error) => () => { throw error }]
+        ]
+    }
+})

--- a/test/unit/http-connection/query.code.test.ts
+++ b/test/unit/http-connection/query.code.test.ts
@@ -212,8 +212,6 @@ describe('QueryRequestCodec', () => {
 
     })
 
-
-
     function subject(params?: Partial<{
         auth: types.AuthToken,
         query: string,

--- a/test/unit/http-connection/transaction.codec.test.ts
+++ b/test/unit/http-connection/transaction.codec.test.ts
@@ -348,7 +348,7 @@ describe('CommitTransactionResponseCodec', () => {
             const codec = subject({ rawQueryResponse: { bookmarks }})
 
             expect(codec.meta).toEqual({
-                bookmarks
+                bookmark: bookmarks
             })
         })
 

--- a/test/unit/http-connection/transaction.codec.test.ts
+++ b/test/unit/http-connection/transaction.codec.test.ts
@@ -164,7 +164,7 @@ describe('BeginTransactionResponseCodec', () => {
     const DEFAULT_RAW_RESPONSE = {
         transaction: {
             id: 'abc',
-            expires: 3000
+            expires: '2024-10-18T09:11:12Z'
         }
     }
 
@@ -193,7 +193,7 @@ describe('BeginTransactionResponseCodec', () => {
         it('should handle success', () => {
             const codec = subject()
 
-            expect(codec.expires).toBe(DEFAULT_RAW_RESPONSE.transaction.expires)
+            expect(codec.expires).toEqual(new Date(DEFAULT_RAW_RESPONSE.transaction.expires))
         })
 
         it('should handle failures', () => {

--- a/test/unit/http-connection/transaction.codec.test.ts
+++ b/test/unit/http-connection/transaction.codec.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { auth, types } from "neo4j-driver-core"
+import { 
+    BeginTransactionRequestCodec, 
+    BeginTransactionRequestCodecConfig,
+    CommitTransactionRequestCodec,
+    CommitTransactionRequestCodecConfig, 
+    RollbackTransactionRequestCodec,
+    RollbackTransactionRequestCodecConfig 
+} from "../../../src/http-connection/transaction.codec"
+
+const DEFAULT_AUTH = auth.basic('neo4j', 'password')
+
+
+describe('BeginTransactionRequestCodec', () => { 
+    describe('.contentType', () => {
+        it('should return "application/vnd.neo4j.query"', () => {
+            const codec = subject()
+
+            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+        })
+    })
+
+    describe('.accept', () => {
+        it('should return "application/vnd.neo4j.query, application/json"', () => {
+            const codec = subject()
+
+            expect(codec.accept).toBe('application/vnd.neo4j.query, application/json')
+        })
+    })
+
+    describe('.authorization', () => {
+        it.each([
+            ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+        ])('should handle %s', (_, auth, expected) => {
+            const codec = subject({ auth })
+
+            expect(codec.authorization).toEqual(expected)
+        })
+
+        it.each([
+            ['Kerberos', auth.kerberos('ticket')],
+            ['None', auth.none()],
+            ['MyCustom', auth.custom('principal', 'credentials', 'realm', 'mycustom')],
+        ])('should fail on %s', (_, auth) => {
+            const codec = subject({ auth })
+
+            expect(() => codec.authorization).toThrow(`Authorization scheme "${auth.scheme}" is not supported.`)
+        })
+    })
+
+    function subject(params?: Partial<{
+        auth: types.AuthToken,
+        query: string,
+        parameters: Record<string, unknown>,
+        config: BeginTransactionRequestCodecConfig
+    }>) {
+        return BeginTransactionRequestCodec.of(
+            params?.auth ?? DEFAULT_AUTH,
+            params?.config
+        )
+    }
+})
+
+describe('CommitTransactionRequestCodec', () => { 
+    describe('.contentType', () => {
+        it('should return "application/vnd.neo4j.query"', () => {
+            const codec = subject()
+
+            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+        })
+    })
+
+    describe('.accept', () => {
+        it('should return "application/vnd.neo4j.query, application/json"', () => {
+            const codec = subject()
+
+            expect(codec.accept).toBe('application/vnd.neo4j.query, application/json')
+        })
+    })
+
+    describe('.authorization', () => {
+        it.each([
+            ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+        ])('should handle %s', (_, auth, expected) => {
+            const codec = subject({ auth })
+
+            expect(codec.authorization).toEqual(expected)
+        })
+
+        it.each([
+            ['Kerberos', auth.kerberos('ticket')],
+            ['None', auth.none()],
+            ['MyCustom', auth.custom('principal', 'credentials', 'realm', 'mycustom')],
+        ])('should fail on %s', (_, auth) => {
+            const codec = subject({ auth })
+
+            expect(() => codec.authorization).toThrow(`Authorization scheme "${auth.scheme}" is not supported.`)
+        })
+    })
+
+    function subject(params?: Partial<{
+        auth: types.AuthToken,
+        query: string,
+        parameters: Record<string, unknown>,
+        config: CommitTransactionRequestCodecConfig
+    }>) {
+        return CommitTransactionRequestCodec.of(
+            params?.auth ?? DEFAULT_AUTH,
+            params?.config
+        )
+    }
+})
+
+describe('RollbackTransactionRequestCodec', () => { 
+    describe('.contentType', () => {
+        it('should return "application/vnd.neo4j.query"', () => {
+            const codec = subject()
+
+            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+        })
+    })
+
+    describe('.accept', () => {
+        it('should return "application/vnd.neo4j.query, application/json"', () => {
+            const codec = subject()
+
+            expect(codec.accept).toBe('application/vnd.neo4j.query, application/json')
+        })
+    })
+
+    describe('.authorization', () => {
+        it.each([
+            ['Basic', auth.basic('myuser', 'mypassword'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Bearer', auth.bearer('mytoken'), 'Bearer bXl0b2tlbg=='],
+            ['Custom Basic', auth.custom('myuser', 'mypassword', '', 'basic'), 'Basic bXl1c2VyOm15cGFzc3dvcmQ='],
+            ['Custom Bearer', auth.custom('', 'mytoken', '', 'bearer'), 'Bearer bXl0b2tlbg=='],
+        ])('should handle %s', (_, auth, expected) => {
+            const codec = subject({ auth })
+
+            expect(codec.authorization).toEqual(expected)
+        })
+
+        it.each([
+            ['Kerberos', auth.kerberos('ticket')],
+            ['None', auth.none()],
+            ['MyCustom', auth.custom('principal', 'credentials', 'realm', 'mycustom')],
+        ])('should fail on %s', (_, auth) => {
+            const codec = subject({ auth })
+
+            expect(() => codec.authorization).toThrow(`Authorization scheme "${auth.scheme}" is not supported.`)
+        })
+    })
+
+    function subject(params?: Partial<{
+        auth: types.AuthToken,
+        query: string,
+        parameters: Record<string, unknown>,
+        config: RollbackTransactionRequestCodecConfig
+    }>) {
+        return RollbackTransactionRequestCodec.of(
+            params?.auth ?? DEFAULT_AUTH,
+            params?.config
+        )
+    }
+})

--- a/test/unit/http-connection/transaction.codec.test.ts
+++ b/test/unit/http-connection/transaction.codec.test.ts
@@ -29,10 +29,10 @@ const DEFAULT_AUTH = auth.basic('neo4j', 'password')
 
 describe('BeginTransactionRequestCodec', () => { 
     describe('.contentType', () => {
-        it('should return "application/vnd.neo4j.query"', () => {
+        it('should return "application/json"', () => {
             const codec = subject()
 
-            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+            expect(codec.contentType).toBe('application/json')
         })
     })
 
@@ -82,10 +82,10 @@ describe('BeginTransactionRequestCodec', () => {
 
 describe('CommitTransactionRequestCodec', () => { 
     describe('.contentType', () => {
-        it('should return "application/vnd.neo4j.query"', () => {
+        it('should return "application/json"', () => {
             const codec = subject()
 
-            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+            expect(codec.contentType).toBe('application/json')
         })
     })
 
@@ -135,10 +135,10 @@ describe('CommitTransactionRequestCodec', () => {
 
 describe('RollbackTransactionRequestCodec', () => { 
     describe('.contentType', () => {
-        it('should return "application/vnd.neo4j.query"', () => {
+        it('should return "application/json"', () => {
             const codec = subject()
 
-            expect(codec.contentType).toBe('application/vnd.neo4j.query')
+            expect(codec.contentType).toBe('application/json')
         })
     })
 


### PR DESCRIPTION
The explicit transaction enables the apis `Driver.executeQuery`, `Session.beginTransaction`, `Session.executeRead` and `Session.executeWrite`.

The access to the `Transaction` object is also granted. All limitations around transactions in the drivers are also applicable here.

In manner to transactions work in a cluster environments, the members of the clusters should have a session affinity header should be configured on the reverse proxy.

This is needed since the transaction lives on a single instance of the cluster and it is not shared between members.

By default, the session session affinity header name is `neo4j-cluster-affinity`.

This header name can be configured in the wrapper creation by using the `httpSessionAffinityHeader` property on the configuration.