### PR TITLE
Adjust test addresses and clean up discovery promisse

### DIFF
--- a/src/http-connection/connection-provider.http.ts
+++ b/src/http-connection/connection-provider.http.ts
@@ -105,6 +105,9 @@ export default class HttpConnectionProvider extends ConnectionProvider {
         if (this._queryEndpoint == null) {
             if (this._discoveryPromise == null) {
                 this._discoveryPromise = HttpConnection.discover({ address: this._address, scheme: this._scheme })
+                    .finally(() => {
+                        this._discoveryPromise = undefined
+                    })
             }
 
             const discoveryResult = await this._discoveryPromise

--- a/test/integration/minimum.test.ts
+++ b/test/integration/minimum.test.ts
@@ -411,7 +411,7 @@ when(config.version >= 5.23, () => describe.each(runners())('minimum requirement
 
   it('should be able to handle password rotation', async () => {
     let password = config.password + 'wrong'
-    wrapper = neo4j.wrapper(`http://${config.hostname}:${config.httpPort}`,
+    wrapper = neo4j.wrapper(`${config.httpScheme}://${config.hostname}:${config.httpPort}`,
       neo4j.authTokenManagers.basic({ tokenProvider: async () => {
           try {
             return neo4j.auth.basic(config.username, password)

--- a/test/integration/transactions.test.ts
+++ b/test/integration/transactions.test.ts
@@ -146,7 +146,7 @@ when(config.version >= 5.26, () => describe('transactions', () => {
     it('should be able to handle password rotation on executeWrite', async () => {
       let password = config.password + 'wrong'
       let passwordCall = 0
-      wrapper = neo4j.wrapper(`http://${config.hostname}:${config.httpPort}`,
+      wrapper = neo4j.wrapper(`${config.httpScheme}://${config.hostname}:${config.httpPort}`,
         neo4j.authTokenManagers.basic({ tokenProvider: async () => {
             try {
               return neo4j.auth.basic(config.username, password)


### PR DESCRIPTION
The address configuration for the password rotation test cases were not using the configured http schema, so they were failing when tested with https.

Apart of this, the driver was re-triggering the discovery when failing since the promise was never cleaned.